### PR TITLE
[feat] [MN-10] 댓글 수정 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.sprint.mission.sb03monewteam1.controller;
 import com.sprint.mission.sb03monewteam1.controller.api.CommentApi;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.service.CommentService;
 import jakarta.validation.Valid;
@@ -13,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -59,6 +62,25 @@ public class CommentController implements CommentApi {
         );
         log.info("댓글 목록 조회 완료");
         log.info("조회된 댓글 수: {}", result.content().size());
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(result);
+    }
+
+    @Override
+    @PatchMapping(path = "/{commentId}")
+    public ResponseEntity<CommentDto> update(
+        @PathVariable UUID commentId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId,
+        @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+    ) {
+        String updateContent = commentUpdateRequest.content();
+        log.info("댓글 수정 요청: commentId = {}, userId = {}, 수정 내용 = {}", commentId, userId, updateContent);
+
+        CommentDto result = commentService.update(commentId, userId, commentUpdateRequest);
+
+        log.info("댓글 수정 완료");
 
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
@@ -2,17 +2,22 @@ package com.sprint.mission.sb03monewteam1.controller.api;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -83,5 +88,54 @@ public interface CommentApi {
         @RequestParam(required = false) String cursor,
         @RequestParam(required = false) Instant after,
         @RequestParam int limit
+    );
+
+    @Operation(summary = "댓글 정보 수정")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "수정 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = CommentDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (입력값 검증 실패)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "작성자 아님",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<CommentDto> update(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Monew-Request-User-ID") UUID userId,
+        @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
     );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.sb03monewteam1.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record CommentUpdateRequest(
+    String content
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentUpdateRequest.java
@@ -1,9 +1,14 @@
 package com.sprint.mission.sb03monewteam1.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record CommentUpdateRequest(
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(min = 1, max = 500, message = "댓글 내용은 1자 이상 500자 이하여야 합니다.")
     String content
 ) {
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "기사를 찾을 수 없습니다."),
     DUPLICATE_ARTICLE_VIEW(HttpStatus.CONFLICT, "이미 조회한 기사입니다."),
 
+    // 댓글 관련 예외
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+
     // 커서 기반 페이지네이션 관련 예외
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 커서 형식입니다."),
     INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST,"잘못된 ID 커서 형식입니다."),

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentNotFoundException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.sb03monewteam1.exception.comment;
+
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class CommentNotFoundException extends CommentException {
+
+    public CommentNotFoundException(UUID commentId) {
+        super(ErrorCode.COMMENT_NOT_FOUND, Map.of("commentID", String.valueOf(commentId)));
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/UnauthorizedCommentAccessException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/UnauthorizedCommentAccessException.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.sb03monewteam1.exception.comment;
+
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+
+public class UnauthorizedCommentAccessException extends CommentException {
+
+    public UnauthorizedCommentAccessException() {
+        super(ErrorCode.FORBIDDEN_ACCESS);
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.service;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import java.time.Instant;
 import java.util.UUID;
@@ -18,4 +19,6 @@ public interface CommentService {
         String sortBy,
         String sortDirection
     );
+
+    CommentDto update(UUID commentId, UUID userId, CommentUpdateRequest commentUpdateRequest);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.service;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
@@ -144,6 +145,12 @@ public class CommentServiceImpl implements CommentService {
             totalElements,
             hasNext
         );
+    }
+
+    @Override
+    public CommentDto update(UUID commentId, UUID userId,
+        CommentUpdateRequest commentUpdateRequest) {
+        return null;
     }
 
     private Instant parseInstant(String cursorValue) {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -451,9 +451,6 @@ public class CommentControllerTest {
             CommentUpdateRequest commentUpdateRequest = CommentUpdateRequest.builder()
                 .content(updateContent)
                 .build();
-            CommentDto expectedCommentDto = CommentFixture.createCommentDtoWithContent(comment, updateContent);
-
-            given(commentService.update(commentId, userId, commentUpdateRequest)).willReturn(expectedCommentDto);
 
             // When & Then
             mockMvc.perform(patch("/api/comments/" + commentId.toString())

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -4,12 +4,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
@@ -30,7 +29,6 @@ import com.sprint.mission.sb03monewteam1.service.CommentService;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
@@ -366,10 +364,10 @@ public class CommentControllerTest {
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .header("Monew-Request-User-ID", userId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(commentId))
-                .andExpect(jsonPath("$.articleId").value(article.getId()))
-                .andExpect(jsonPath("$.userId").value(userId))
-                .andExpect(jsonPath("$.userNickName").value(user.getNickname()))
+                .andExpect(jsonPath("$.id").value(commentId.toString()))
+                .andExpect(jsonPath("$.articleId").value(article.getId().toString()))
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.userNickname").value(user.getNickname()))
                 .andExpect(jsonPath("$.content").value(updateContent));
         }
 
@@ -463,7 +461,7 @@ public class CommentControllerTest {
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .header("Monew-Request-User-ID", userId))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("잘못된 입력값입니다."));
+                .andExpect(jsonPath("$.code").value(ErrorCode.VALIDATION_ERROR.name()));
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentFixture.java
@@ -59,4 +59,17 @@ public class CommentFixture {
                 .likedByMe(false)
                 .build();
     }
+
+    public static CommentDto createCommentDtoWithContent(Comment comment, String newContent) {
+        return CommentDto.builder()
+            .id(comment.getId())
+            .createdAt(comment.getCreatedAt())
+            .articleId(comment.getArticle().getId())
+            .userId(comment.getAuthor().getId())
+            .content(newContent)
+            .userNickname(comment.getAuthor().getNickname())
+            .likeCount(0L)
+            .likedByMe(false)
+            .build();
+    }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -15,6 +15,7 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentNotFoundException;
+import com.sprint.mission.sb03monewteam1.exception.comment.UnauthorizedCommentAccessException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
@@ -600,7 +601,7 @@ public class CommentServiceTest {
             // when & then
             assertThatThrownBy(() ->
                 commentService.update(commentId, otherUserId, commentUpdateRequest
-                )).isInstanceOf(ForbiddenAccessException.class)
+                )).isInstanceOf(UnauthorizedCommentAccessException.class)
                 .hasMessageContaining(ErrorCode.FORBIDDEN_ACCESS.getMessage());
         }
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -8,14 +8,17 @@ import static org.mockito.BDDMockito.given;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import com.sprint.mission.sb03monewteam1.exception.comment.CommentNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
+import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
 import com.sprint.mission.sb03monewteam1.fixture.ArticleFixture;
 import com.sprint.mission.sb03monewteam1.fixture.CommentFixture;
 import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
@@ -23,6 +26,7 @@ import com.sprint.mission.sb03monewteam1.mapper.CommentMapper;
 import com.sprint.mission.sb03monewteam1.repository.ArticleRepository;
 import com.sprint.mission.sb03monewteam1.repository.CommentRepository;
 import com.sprint.mission.sb03monewteam1.repository.UserRepository;
+import java.sql.Ref;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -509,6 +513,95 @@ public class CommentServiceTest {
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_DIRECTION.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 수정 테스트")
+    class CommentUpdateTest {
+
+        @Test
+        void 댓글을_수정하면_수정된_CommentDTO를_반환해야_한다() {
+
+            // given
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            UUID userId = user.getId();
+            Article article = ArticleFixture.createArticleWithId(UUID.randomUUID());
+            String originalContent = "기존 댓글";
+            String updateContent = "댓글 수정 테스트";
+            Comment comment = CommentFixture.createComment(originalContent, user, article);
+            ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+            UUID commentId = comment.getId();
+
+            CommentUpdateRequest commentUpdateRequest = CommentUpdateRequest.builder()
+                .content(updateContent)
+                .build();
+            CommentDto expectedCommentDto = CommentFixture.createCommentDtoWithContent(comment, updateContent);
+
+            given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+            given(commentMapper.toDto(any(Comment.class))).willReturn(expectedCommentDto);
+
+            // when
+            CommentDto result = commentService.update(commentId, userId, commentUpdateRequest);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(commentId);
+            assertThat(result.content()).isEqualTo(updateContent);
+        }
+
+        @Test
+        void 댓글을_수정할_때_존재하지_않는_댓글이라면_예외가_발생한다() {
+
+            // given
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            UUID userId = user.getId();
+            String updateContent = "댓글 수정 테스트";
+            UUID invalidCommentId = UUID.randomUUID();
+
+            CommentUpdateRequest commentUpdateRequest = CommentUpdateRequest.builder()
+                .content(updateContent)
+                .build();
+
+            given(commentRepository.findById(invalidCommentId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                commentService.update(invalidCommentId, userId, commentUpdateRequest
+                )).isInstanceOf(CommentNotFoundException.class)
+                .hasMessageContaining(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        void 댓글을_수정할_때_작성자가_아니라면_예외가_발생한다() {
+
+            // given
+            User author = UserFixture.createUser();
+            ReflectionTestUtils.setField(author, "id", UUID.randomUUID());
+            User otherUser = UserFixture.createUser();
+            ReflectionTestUtils.setField(otherUser, "id", UUID.randomUUID());
+            UUID otherUserId = otherUser.getId();
+
+            Article article = ArticleFixture.createArticleWithId(UUID.randomUUID());
+            String originalContent = "기존 댓글";
+            String updateContent = "댓글 수정 테스트";
+            Comment comment = CommentFixture.createComment(originalContent, author, article);
+            ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+            UUID commentId = comment.getId();
+
+            CommentUpdateRequest commentUpdateRequest = CommentUpdateRequest.builder()
+                .content(updateContent)
+                .build();
+
+            given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+            // when & then
+            assertThatThrownBy(() ->
+                commentService.update(commentId, otherUserId, commentUpdateRequest
+                )).isInstanceOf(ForbiddenAccessException.class)
+                .hasMessageContaining(ErrorCode.FORBIDDEN_ACCESS.getMessage());
         }
     }
 


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 수정 기능 구현

### ✅ 완료한 작업
- [x] 댓글 수정 로직 구현
- [x] 댓글 수정 컨트롤러/서비스 테스트 작성

### 🧪 테스트 결과
- 모든 테스트 통과
- 로컬 환경에서 정상 동작 확인

### ⚠️ 기타 참고 사항
- 작성자가 아닌 경우 403 Forbidden 응답 처리
- API 명세(Swagger)에 403 응답 코드 추가

### Related Issue

Closes #48 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 댓글 수정(PATCH) 기능이 추가되어 사용자가 자신의 댓글 내용을 1~500자 이내로 수정할 수 있습니다.
  * 댓글이 존재하지 않거나 작성자가 아닌 경우 각각 404 또는 403 에러가 반환됩니다.
  * 댓글 수정 요청 시 상세한 오류 응답이 제공됩니다.

* **Bug Fixes**
  * 댓글 조회 실패 시 적절한 에러 메시지가 제공됩니다.

* **Tests**
  * 댓글 수정 기능에 대한 다양한 시나리오(성공, 권한 없음, 존재하지 않음, 유효성 실패) 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->