### PR TITLE
[feat] [MN-58] 댓글 논리 삭제 조회 방식 커스텀 쿼리로 변경

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
@@ -12,7 +12,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Where;
 
 @Builder
 @Entity

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
@@ -20,7 +20,6 @@ import org.hibernate.annotations.Where;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Where(clause = "is_deleted = false")
 public class Comment extends BaseUpdatableEntity {
 
     @Column(name = "content", nullable = false, length = 500)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
+import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -23,4 +25,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
         + " c.isDeleted = true"
         + " WHERE c.id = :commentId")
     void decreaseLikeCountAndDeleteById(@Param("commentId") UUID commentId);
+
+    Optional<Comment> findByIdAndIsDeletedFalse(UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -1,6 +1,5 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
-import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryImpl.java
@@ -35,6 +35,10 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom{
 
         // where 조건 생성을 위한 빌더
         BooleanBuilder where = new BooleanBuilder();
+
+        // 논리 삭제 제외 조건 추가
+        where.and(qComment.isDeleted.isFalse());
+
         if (articleId != null) {
             where.and(qComment.article.id.eq(articleId));
         }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/UserRepository.java
@@ -1,15 +1,20 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
+import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByIdAndIsDeletedFalse(UUID id);
 
     Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -46,9 +46,9 @@ public class CommentServiceImpl implements CommentService {
 
         log.info("댓글 등록 시작: 기사 = {}, 작성자 = {}, 내용 = {}", articleId, userId, content);
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndIsDeletedFalse(userId)
                 .orElseThrow(() -> new CommentException(ErrorCode.USER_NOT_FOUND));
-        Article article = articleRepository.findById(articleId)
+        Article article = articleRepository.findByIdAndIsDeletedFalse(articleId)
                 .orElseThrow(() -> new CommentException(ErrorCode.ARTICLE_NOT_FOUND));
 
         Comment comment = Comment.builder()
@@ -75,7 +75,7 @@ public class CommentServiceImpl implements CommentService {
             , articleId, cursor, nextAfter, size, sortBy, sortDirection);
 
         if (articleId != null) {
-            articleRepository.findById(articleId)
+            articleRepository.findByIdAndIsDeletedFalse(articleId)
                 .orElseThrow(() -> new CommentException(ErrorCode.ARTICLE_NOT_FOUND));
         }
 
@@ -159,7 +159,7 @@ public class CommentServiceImpl implements CommentService {
 
         log.info("댓글 수정 시작 : 댓글 ID = {}, 유저 ID = {}", commentId, userId);
 
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
             .orElseThrow(() -> new CommentNotFoundException(commentId));
 
         validateAuthor(comment, userId);
@@ -177,7 +177,7 @@ public class CommentServiceImpl implements CommentService {
 
         log.info("댓글 논리 삭제 시작 : 댓글 ID = {}, 유저 ID = {}", commentId, userId);
 
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
             .orElseThrow(() -> new CommentNotFoundException(commentId));
 
         validateAuthor(comment, userId);

--- a/src/test/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryTest.java
@@ -240,7 +240,7 @@ public class CommentRepositoryTest {
         UUID id = deletedComment.getId();
 
         // when
-        Optional<Comment> result = commentRepository.findById(id);
+        Optional<Comment> result = commentRepository.findByIdAndIsDeletedFalse(id);
 
         // then
         assertThat(result).isEmpty();
@@ -257,7 +257,7 @@ public class CommentRepositoryTest {
         UUID id = comment.getId();
 
         // when
-        Optional<Comment> result = commentRepository.findById(id);
+        Optional<Comment> result = commentRepository.findByIdAndIsDeletedFalse(id);
 
         // then
         assertThat(result).isPresent();

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -91,8 +91,8 @@ public class CommentServiceTest {
             Comment savedComment = CommentFixture.createComment(content,user, article);
             CommentDto expectedCommentDto = CommentFixture.createCommentDto(savedComment);
 
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(userRepository.findByIdAndIsDeletedFalse(userId)).willReturn(Optional.of(user));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.save(any(Comment.class))).willReturn(savedComment);
             given(commentMapper.toDto(any(Comment.class))).willReturn(expectedCommentDto);
 
@@ -120,7 +120,7 @@ public class CommentServiceTest {
 
             CommentRegisterRequest commentRegisterRequest = CommentFixture.createCommentRegisterRequest(content, invalidUserId, articleId);
 
-            given(userRepository.findById(invalidUserId)).willReturn(Optional.empty());
+            given(userRepository.findByIdAndIsDeletedFalse(invalidUserId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> commentService.create(commentRegisterRequest))
@@ -142,8 +142,8 @@ public class CommentServiceTest {
 
             CommentRegisterRequest commentRegisterRequest = CommentFixture.createCommentRegisterRequest(content, userId, invalidArticleId);
 
-            given(userRepository.findById(userId)).willReturn(Optional.of(user));
-            given(articleRepository.findById(invalidArticleId)).willReturn(Optional.empty());
+            given(userRepository.findByIdAndIsDeletedFalse(userId)).willReturn(Optional.of(user));
+            given(articleRepository.findByIdAndIsDeletedFalse(invalidArticleId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> commentService.create(commentRegisterRequest))
@@ -177,7 +177,7 @@ public class CommentServiceTest {
 
             List<Comment> firstPage = sorted.subList(0, pageSize + 1);
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(firstPage);
@@ -232,7 +232,7 @@ public class CommentServiceTest {
 
             List<Comment> firstPage = sorted.subList(0, pageSize + 1);
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(firstPage);
@@ -282,7 +282,7 @@ public class CommentServiceTest {
             Instant cursor = lastOfFirstPage.getCreatedAt();
             Instant after = lastOfFirstPage.getCreatedAt();
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(cursor.toString()), eq(after), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(secondPage);
@@ -337,7 +337,7 @@ public class CommentServiceTest {
 
             List<Comment> lastPage = sorted.subList(pageSize, sorted.size());
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(nextCursor.toString()), eq(nextAfter), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(lastPage);
@@ -382,7 +382,7 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String sortDirection = "DESC";
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(Collections.emptyList());
@@ -416,7 +416,7 @@ public class CommentServiceTest {
 
             List<Comment> commentList = createCommentsWithCreatedAt(pageSize, article, user);
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(commentList.subList(0, pageSize));
@@ -448,7 +448,7 @@ public class CommentServiceTest {
 
             List<Comment> comments = createCommentsWithCreatedAt(pageSize, article, user);
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
@@ -467,7 +467,7 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String sortDirection = "DESC";
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
@@ -486,7 +486,7 @@ public class CommentServiceTest {
             int pageSize = 5;
             String sortDirection = "DESC";
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
@@ -506,7 +506,7 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String invalidSortDirection = "unknownDirection";  // 허용되지 않은 정렬 방향
 
-            given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
@@ -540,7 +540,7 @@ public class CommentServiceTest {
                 .build();
             CommentDto expectedCommentDto = CommentFixture.createCommentDtoWithContent(comment, updateContent);
 
-            given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+            given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
             given(commentMapper.toDto(any(Comment.class))).willReturn(expectedCommentDto);
 
             // when
@@ -566,7 +566,7 @@ public class CommentServiceTest {
                 .content(updateContent)
                 .build();
 
-            given(commentRepository.findById(invalidCommentId)).willReturn(Optional.empty());
+            given(commentRepository.findByIdAndIsDeletedFalse(invalidCommentId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
@@ -596,7 +596,7 @@ public class CommentServiceTest {
                 .content(updateContent)
                 .build();
 
-            given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+            given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
 
             // when & then
             assertThatThrownBy(() ->
@@ -625,7 +625,7 @@ public class CommentServiceTest {
             ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
             UUID commentId = comment.getId();
 
-            given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+            given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
 
             // when
             Comment result = commentService.delete(commentId, user.getId());
@@ -643,14 +643,14 @@ public class CommentServiceTest {
             UUID commentId = UUID.randomUUID();
             UUID userId = UUID.randomUUID();
 
-            given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+            given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.empty());
 
             // when & then
             Assertions.assertThatThrownBy(() -> {
                 commentService.delete(commentId, userId);
                 }).isInstanceOf(CommentNotFoundException.class);
 
-            then(commentRepository).should().findById(commentId);
+            then(commentRepository).should().findByIdAndIsDeletedFalse(commentId);
         }
 
         @Test
@@ -667,14 +667,14 @@ public class CommentServiceTest {
             ReflectionTestUtils.setField(deletedComment, "id", UUID.randomUUID());
             UUID deletedCommentId = deletedComment.getId();
 
-            given(commentRepository.findById(deletedCommentId)).willReturn(Optional.empty());
+            given(commentRepository.findByIdAndIsDeletedFalse(deletedCommentId)).willReturn(Optional.empty());
 
             // when & then
             Assertions.assertThatThrownBy(() -> {
                 commentService.delete(deletedCommentId, user.getId());
             }).isInstanceOf(CommentNotFoundException.class);
 
-            then(commentRepository).should().findById(deletedCommentId);
+            then(commentRepository).should().findByIdAndIsDeletedFalse(deletedCommentId);
         }
     }
 


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 논리 삭제 조회 방식 커스텀 쿼리로 변경

### ✅ 완료한 작업
- [x] 엔티티 @where 어노테이션 삭제
- [x] 레포지토리  findByIdAndIsDeletedFalse 메서드 추가 

### 🧪 테스트 결과
- 모든  테스트 통과 완료

### ⚠️ 기타 참고 사항
- 아직 남은 작업이나, 리뷰어가 확인해야 할 이슈

### Related Issue

Closes  #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 삭제된 댓글이 조회되지 않도록 댓글 조회 로직이 개선되었습니다.

* **테스트**
  * 삭제된 댓글이 조회되지 않는지 확인하는 테스트가 추가 및 수정되었습니다.  
  * 댓글, 사용자, 게시글의 삭제 여부를 반영하여 테스트가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->