### PR TITLE
[feat] [MN-14] 댓글 물리 삭제 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -105,4 +105,18 @@ public class CommentController implements CommentApi {
             .status(HttpStatus.NO_CONTENT)
             .build();
     }
+
+    @Override
+    @DeleteMapping(path = "/{commentId}/hard")
+    public ResponseEntity<Void> deleteHard(@PathVariable UUID commentId) {
+
+        log.info("댓글 물리 삭제 요청: commentId = {}", commentId);
+
+        commentService.deleteHard(commentId);
+
+        log.info("댓글 물리삭제 완료: commentId = {}", commentId);
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
@@ -174,4 +174,30 @@ public interface CommentApi {
         @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
         @RequestHeader("Monew-Request-User-ID") UUID userId
     );
+
+    @Operation(summary = "댓글 물리 삭제")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204", description = "삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> deleteHard(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId
+    );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -14,4 +14,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     @Query("SELECT c FROM CommentLike c LEFT JOIN FETCH c.comment WHERE c.user.id = :userId")
     List<CommentLike> findAllByUserId(@Param("userId") UUID userId);
 
+    Object deleteByCommentId(UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -14,5 +14,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     @Query("SELECT c FROM CommentLike c LEFT JOIN FETCH c.comment WHERE c.user.id = :userId")
     List<CommentLike> findAllByUserId(@Param("userId") UUID userId);
 
-    Object deleteByCommentId(UUID commentId);
+    void deleteByCommentId(UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -24,4 +24,6 @@ public interface CommentService {
     CommentDto update(UUID commentId, UUID userId, CommentUpdateRequest commentUpdateRequest);
 
     Comment delete(UUID commentId, UUID userId);
+
+    void deleteHard(UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -190,6 +190,11 @@ public class CommentServiceImpl implements CommentService {
         return comment;
     }
 
+    @Override
+    public void deleteHard(UUID commentId) {
+        return ;
+    }
+
     private void validateAuthor(Comment comment, UUID userId) {
         if (!comment.getAuthor().getId().equals(userId)) {
             throw new UnauthorizedCommentAccessException();

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -3,6 +3,9 @@ package com.sprint.mission.sb03monewteam1.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -550,6 +553,42 @@ public class CommentControllerTest {
                     .header("Monew-Request-User-ID", otherUserId))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN_ACCESS.name()))
+                .andExpect(jsonPath("$.message").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 물리 삭제 테스트")
+    class CommentDeleteHardTest {
+
+        @Test
+        void 댓글을_물리삭제하면_204가_반환되어야_한다() throws Exception {
+
+            // given
+            UUID commentId = UUID.randomUUID();
+
+            willDoNothing().given(commentService).deleteHard(commentId);
+
+            // when & then
+            mockMvc.perform(delete("/api/comments/" + commentId + "/hard"))
+                .andExpect(status().isNoContent());
+
+            then(commentService).should().deleteHard(commentId);
+        }
+
+        @Test
+        void 댓글을_물리삭제할_때_존재하지_않는_댓글이면_404가_반환되어야_한다() throws Exception {
+
+            // given
+            UUID commentId = UUID.randomUUID();
+
+            willThrow(new CommentNotFoundException(commentId))
+                .given(commentService).deleteHard(commentId);
+
+            // when & then
+            mockMvc.perform(delete("/api/comments/" + commentId + "/hard"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.COMMENT_NOT_FOUND.name()))
                 .andExpect(jsonPath("$.message").exists());
         }
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -765,7 +765,7 @@ public class CommentServiceTest {
             Article article = ArticleFixture.createArticleWithCommentCount(1L);
 
             Comment deletedComment = CommentFixture.createComment("삭제된 댓글", user, article);
-            deletedComment.delete(); // isDeleted = true
+            deletedComment.delete();
             ReflectionTestUtils.setField(deletedComment, "id", commentId);
 
             given(commentRepository.findById(commentId)).willReturn(Optional.of(deletedComment));

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -722,6 +722,7 @@ public class CommentServiceTest {
             UUID commentId = UUID.randomUUID();
             User user = UserFixture.createUser();
             Article article = ArticleFixture.createArticleWithCommentCount(1L);
+            ReflectionTestUtils.setField(article, "id", UUID.randomUUID());
             Comment comment = CommentFixture.createComment("댓글 물리 삭제 테스트", user, article);
             ReflectionTestUtils.setField(comment, "id", commentId);
 


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 물리 삭제 기능 구현

### ✅ 완료한 작업
- [x] 댓글 물리 삭제 로직 구현
    - [x]  논리 삭제 상태에 따른 기사 댓글 수 감소 처리 분기
    - [x] 댓글 좋아요(commentLike) 연관 삭제 처리
- [x] 컨트롤러/서비스 테스트 코드 작성

### 🧪 테스트 결과
- 테스트 코드 통과
- Postman 테스트 완료 등

### ⚠️ 기타 참고 사항
- 아직 남은 작업이나, 리뷰어가 확인해야 할 이슈

### Related Issue

Closes #60 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 댓글을 완전히 삭제(물리 삭제)할 수 있는 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 물리 삭제 시 존재하지 않는 댓글에 대한 404 오류 처리가 반영되었습니다.

* **테스트**
  * 댓글 물리 삭제 및 관련 예외 상황에 대한 테스트가 추가되었습니다.
  * 논리 삭제 시 권한 예외 테스트가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->