### PR TITLE
[feat] [MN-29] 사용자 물리 삭제 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/UserController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/UserController.java
@@ -96,4 +96,21 @@ public class UserController implements UserApi {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @Override
+    @DeleteMapping("/{userId}/hard")
+    public ResponseEntity<Void> deleteHard(
+        @PathVariable UUID userId,
+        HttpServletRequest httpServletRequest
+    ) {
+        log.info("사용자 물리 삭제 요청: userId={}", userId);
+        UUID requestUserId = (UUID) httpServletRequest.getAttribute("userId");
+        log.info("Monew-Request-User-ID: {}", requestUserId);
+
+        userService.deleteHard(requestUserId, userId);
+
+        log.info("사용자 물리 삭제 완료: id={}", userId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/UserApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/UserApi.java
@@ -184,4 +184,41 @@ public interface UserApi {
         HttpServletRequest httpServletRequest
     );
 
+    @Operation(summary = "사용자 물리 삭제", description = "사용자를 물리적으로 삭제합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "사용자 삭제 성공"
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "사용자 삭제 권한 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> deleteHard(
+        @Parameter(description = "삭제할 사용자 ID", required = true)
+        UUID userId,
+        HttpServletRequest httpServletRequest
+    );
+
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     // 사용자 관련 예외
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "잘못된 로그인 입력 값 입니다."),
+    INVALID_USER_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
 
     // 관심사 관련 예외

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -14,4 +14,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     @Query("SELECT c FROM CommentLike c LEFT JOIN FETCH c.comment WHERE c.user.id = :userId")
     List<CommentLike> findAllByUserId(@Param("userId") UUID userId);
 
+    void deleteByUserId(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -15,4 +15,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     List<CommentLike> findAllByUserId(@Param("userId") UUID userId);
 
     void deleteByUserId(UUID userId);
+
+    void deleteByCommentId(UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,4 +27,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
     void decreaseLikeCountAndDeleteById(@Param("commentId") UUID commentId);
 
     Optional<Comment> findByIdAndIsDeletedFalse(UUID commentId);
+
+    List<Comment> findByAuthorId(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -20,11 +20,10 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
     int increaseLikeCount(@Param("commentId") UUID commentId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE Comment c "
-        + "SET c.likeCount = CASE WHEN c.likeCount > 0 THEN c.likeCount - 1 ELSE 0 END,"
-        + " c.isDeleted = true"
-        + " WHERE c.id = :commentId")
-    void decreaseLikeCountAndDeleteById(@Param("commentId") UUID commentId);
+    @Query("UPDATE Comment c " +
+        "SET c.likeCount = CASE WHEN c.likeCount > 0 THEN c.likeCount - 1 ELSE 0 END " +
+        "WHERE c.id = :commentId")
+    void decreaseLikeCountById(@Param("commentId") UUID commentId);
 
     Optional<Comment> findByIdAndIsDeletedFalse(UUID commentId);
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/InterestRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/InterestRepository.java
@@ -3,7 +3,6 @@ package com.sprint.mission.sb03monewteam1.repository;
 import com.sprint.mission.sb03monewteam1.entity.Interest;
 import java.util.List;
 import java.util.UUID;
-import com.sprint.mission.sb03monewteam1.entity.Interest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
@@ -13,4 +13,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
 
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.interest WHERE s.user.id = :userId")
     List<Subscription> findAllByUserId(@Param("userId") UUID userId);
+
+    void deleteByUserId(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/UserRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/UserRepository.java
@@ -1,12 +1,9 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
-import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserService.java
@@ -16,4 +16,6 @@ public interface UserService {
 
     void delete(UUID requestHeaderUserId, UUID userId);
 
+    void deleteHard(UUID requestHeaderUserId, UUID userId);
+
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -181,8 +181,14 @@ public class UserServiceImpl implements UserService {
 
 
         subscriptionRepository.deleteByUserId(userId);
+        log.debug("구독 객체 삭제 완료");
         commentLikeRepository.deleteByUserId(userId);
+        log.debug("댓글 좋아요 객체 삭제 완료");
+        commentRepository.deleteByAuthorId(userId);
+        log.debug("댓글 객체 삭제 완료");
         userRepository.deleteById(userId);
+        log.debug("사용자 삭제 완료");
+
 
         log.info("사용자 물리 삭제 완료: userId={}", userId);
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -96,12 +96,7 @@ public class UserServiceImpl implements UserService {
     public UserDto update(UUID requestHeaderUserId, UUID userId, UserUpdateRequest request) {
 
         log.info("사용자 정보 수정 시작 - userId={}, nickname={}", userId, request.nickname());
-
-        if (!requestHeaderUserId.equals(userId)) {
-            log.warn("수정 실패 (다른 사용자 정보 수정 요청): requestUserId={}, userId={}", requestHeaderUserId,
-                userId);
-            throw new ForbiddenAccessException("다른 사용자의 정보는 수정할 수 없습니다");
-        }
+        validateOwnership(requestHeaderUserId, userId);
 
         User user = userRepository.findByIdAndIsDeletedFalse(userId)
             .orElseThrow(
@@ -121,27 +116,12 @@ public class UserServiceImpl implements UserService {
     public void delete(UUID requestHeaderUserId, UUID userId) {
 
         log.info("사용자 논리 삭제 시작: userId={}", userId);
-
-        if (!requestHeaderUserId.equals(userId)) {
-            log.warn("논리 삭제 실패 (다른 사용자 논리 삭제 요청): requestUserId={}, userId={}", requestHeaderUserId,
-                userId);
-            throw new ForbiddenAccessException("다른 사용자는 삭제할 수 없습니다");
-        }
+        validateOwnership(requestHeaderUserId, userId);
 
         User user = userRepository.findByIdAndIsDeletedFalse(userId)
             .orElseThrow(() -> new UserNotFoundException(userId));
 
-        user.setDeleted();
-
-        List<Subscription> subscriptions = subscriptionRepository.findAllByUserId(userId);
-        log.debug("사용자 관심사 구독자 수 감소 시작: userId={}", userId);
-        subscriptions.forEach(subscription -> interestRepository.decrementSubscriberCount(subscription.getInterest().getId()));
-        log.debug("사용자 관심사 구독자 수 감소 완료: userId={}", userId);
-
-        List<CommentLike> commentLikes = commentLikeRepository.findAllByUserId(userId);
-        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 시작: userId={}", userId);
-        commentLikes.forEach(commentLike -> commentRepository.decreaseLikeCountAndDeleteById(commentLike.getComment().getId()));
-        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 처리 완료: userId={}", userId);
+        logicallyDeleteUser(user, userId);
 
         log.info("사용자 논리 삭제 완료: userId={}", userId);
 
@@ -151,29 +131,13 @@ public class UserServiceImpl implements UserService {
     public void deleteHard(UUID requestHeaderUserId, UUID userId) {
 
         log.info("사용자 물리 삭제 요청: userId={}", userId);
-        if (!requestHeaderUserId.equals(userId)) {
-            log.warn("물리 삭제 실패 (다른 사용자 물리 삭제 요청): requestUserId={}, userId={}", requestHeaderUserId,
-                userId);
-            throw new ForbiddenAccessException("다른 사용자는 삭제 할 수 없습니다");
-        }
+        validateOwnership(requestHeaderUserId, userId);
 
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserNotFoundException(userId));
 
         if (!user.isDeleted()) {
-
-            user.setDeleted();
-
-            List<Subscription> subscriptions = subscriptionRepository.findAllByUserId(userId);
-            log.debug("사용자 관심사 구독자 수 감소 시작: userId={}", userId);
-            subscriptions.forEach(subscription -> interestRepository.decrementSubscriberCount(subscription.getInterest().getId()));
-            log.debug("사용자 관심사 구독자 수 감소 완료: userId={}", userId);
-
-            List<CommentLike> commentLikes = commentLikeRepository.findAllByUserId(userId);
-            log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 시작: userId={}", userId);
-            commentLikes.forEach(commentLike -> commentRepository.decreaseLikeCountAndDeleteById(commentLike.getComment().getId()));
-            log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 처리 완료: userId={}", userId);
-
+            logicallyDeleteUser(user, userId);
         }
 
         List<Comment> comments = commentRepository.findByAuthorId(userId);
@@ -188,8 +152,31 @@ public class UserServiceImpl implements UserService {
         userRepository.deleteById(userId);
         log.debug("사용자 삭제 완료");
 
-
         log.info("사용자 물리 삭제 완료: userId={}", userId);
 
+    }
+
+    private void validateOwnership(UUID requestHeaderUserId, UUID userId) {
+        if (!requestHeaderUserId.equals(userId)) {
+            log.warn("처리 실패: 다른 사용자 접근 시도 - requestHeaderUserId={}, userId={}",
+                requestHeaderUserId, userId);
+            throw new ForbiddenAccessException("다른 사용자의 정보는 수정 및 삭제할 수 없습니다");
+        }
+    }
+
+    private void logicallyDeleteUser(User user, UUID userId) {
+        user.setDeleted();
+
+        List<Subscription> subscriptions = subscriptionRepository.findAllByUserId(userId);
+        log.debug("사용자 관심사 구독자 수 감소 시작: userId={}", userId);
+        subscriptions.forEach(subscription ->
+            interestRepository.decrementSubscriberCount(subscription.getInterest().getId()));
+        log.debug("사용자 관심사 구독자 수 감소 완료: userId={}", userId);
+
+        List<CommentLike> commentLikes = commentLikeRepository.findAllByUserId(userId);
+        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 시작: userId={}", userId);
+        commentLikes.forEach(commentLike ->
+            commentRepository.decreaseLikeCountAndDeleteById(commentLike.getComment().getId()));
+        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 처리 완료: userId={}", userId);
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -174,9 +174,9 @@ public class UserServiceImpl implements UserService {
         log.debug("사용자 관심사 구독자 수 감소 완료: userId={}", userId);
 
         List<CommentLike> commentLikes = commentLikeRepository.findAllByUserId(userId);
-        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 시작: userId={}", userId);
+        log.debug("댓글 좋아요 수 감소 시작: userId={}", userId);
         commentLikes.forEach(commentLike ->
-            commentRepository.decreaseLikeCountAndDeleteById(commentLike.getComment().getId()));
-        log.debug("댓글 좋아요 수 감소 및 댓글 논리 삭제 처리 완료: userId={}", userId);
+            commentRepository.decreaseLikeCountById(commentLike.getComment().getId()));
+        log.debug("댓글 좋아요 수 감소 완료: userId={}", userId);
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/UserControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/UserControllerTest.java
@@ -15,6 +15,7 @@ import com.sprint.mission.sb03monewteam1.dto.UserDto;
 import com.sprint.mission.sb03monewteam1.dto.request.UserLoginRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.UserRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.UserUpdateRequest;
+import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;
 import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
 import com.sprint.mission.sb03monewteam1.exception.user.InvalidEmailOrPasswordException;
@@ -32,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 @ActiveProfiles("test")
@@ -368,6 +370,72 @@ public class UserControllerTest {
             mockMvc.perform(delete("/api/users/{userId}", userId)
                     .requestAttr("userId", requestHeaderUserId))
                 .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 물리 삭제 테스트")
+    class UserForceDeleteTests {
+
+        @Test
+        void 사용자를_물리_삭제_시_204를_반환해야_한다() throws Exception {
+            // Given
+            UUID requestHeaderUserId = UserFixture.getDefaultId();
+            UUID userId = UserFixture.getDefaultId();
+
+            willDoNothing().given(userService).deleteHard(requestHeaderUserId, userId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/users/{userId}", userId)
+                    .requestAttr("userId", userId))
+                .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 다른_사용자를_물리_삭제_시_403을_반환해야_한다() throws Exception {
+            // Given
+            UUID requestHeaderUserId = UserFixture.getDefaultId();
+            UUID userId = UUID.randomUUID();
+
+            willThrow(new ForbiddenAccessException("다른 사용자를 삭제 할 수 없습니다"))
+                .given(userService).deleteHard(requestHeaderUserId, userId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                    .requestAttr("userId", requestHeaderUserId))
+                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void 존재하지_않는_사용자를_물리_삭제_시_404을_반환해야_한다() throws Exception {
+            // Given
+            UUID requestHeaderUserId = UserFixture.getDefaultId();
+            UUID userId = UserFixture.getDefaultId();
+
+            willThrow(new UserNotFoundException(userId))
+                .given(userService).deleteHard(requestHeaderUserId, userId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                    .requestAttr("userId", requestHeaderUserId))
+                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        void 논리_삭제된_사용자를_물리_삭제_시에도_204를_반환해야_한다() throws Exception {
+            // Given
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            UUID requestHeaderUserId = user.getId();
+            UUID userId = user.getId();
+            user.setDeleted();
+
+            willDoNothing().given(userService).deleteHard(requestHeaderUserId, userId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                    .requestAttr("userId", requestHeaderUserId))
+                .andExpect(status().isNoContent());
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
@@ -233,7 +233,7 @@ public class UserIntegrationTest {
     }
 
     @Test
-    void 사용자_논리_삭제_시_구독자수_좋아요수_감소_및_논리_삭제_적용되어야_한다() throws Exception {
+    void 사용자_논리_삭제_시_구독자수_좋아요_수가_감소되어야_한다() throws Exception {
         // Given
         User user = UserFixture.createUser();
         User savedUser = userRepository.save(user);
@@ -277,9 +277,6 @@ public class UserIntegrationTest {
 
         User deletedUser = userRepository.findById(userId).orElseThrow();
         assertThat(deletedUser.isDeleted()).isTrue();
-
-        Comment deletedComment = commentRepository.findById(savedComment.getId()).orElseThrow();
-        assertThat(deletedComment.getIsDeleted()).isTrue();
 
     }
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
@@ -233,7 +233,7 @@ public class UserIntegrationTest {
     }
 
     @Test
-    void 사용자_삭제_시_구독자수_좋아요수_감소_및_논리삭제_적용되어야_한다() throws Exception {
+    void 사용자_논리_삭제_시_구독자수_좋아요수_감소_및_논리_삭제_적용되어야_한다() throws Exception {
         // Given
         User user = UserFixture.createUser();
         User savedUser = userRepository.save(user);
@@ -258,7 +258,6 @@ public class UserIntegrationTest {
 
         Long beforeSubscriberCount
             = interestRepository.findById(savedInterest.getId()).get().getSubscriberCount();
-
         Long beforeCommentLikeCount
             = commentRepository.findById(savedComment.getId()).get().getLikeCount();
 
@@ -302,7 +301,7 @@ public class UserIntegrationTest {
     }
 
     @Test
-    void 존재하지_않는_사용자를_삭제할_시_404를_반환해야_한다() throws Exception {
+    void 존재하지_않는_사용자를_논리_삭제할_시_404를_반환해야_한다() throws Exception {
         // Given
         UUID requestHeaderUserId = UserFixture.getDefaultId();
         UUID userId = UserFixture.getDefaultId();
@@ -314,7 +313,7 @@ public class UserIntegrationTest {
     }
 
     @Test
-    void 논리_삭제된_사용자를_삭제할_시_404를_반환해야_한다() throws Exception {
+    void 논리_삭제된_사용자를_논리_삭제할_시_404를_반환해야_한다() throws Exception {
         // Given
         User user = UserFixture.createUser();
         user.setDeleted();
@@ -326,6 +325,157 @@ public class UserIntegrationTest {
         mockMvc.perform(delete("/api/users/{userId}", userId)
                 .requestAttr("userId", requestHeaderUserId))
             .andExpect(status().isNotFound());
+
+    }
+
+    @Test
+    void 논리_삭제_되지_않은_사용자를_물리_삭제_시_관련_객체가_모두_제거되어야_한다() throws Exception {
+        // Given
+        User user = UserFixture.createUser();
+        User savedUser = userRepository.save(user);
+
+        User otherUser = UserFixture.createUser("other@example.com", "otherUser", "Password123!");
+        User savedOtherUser = userRepository.save(otherUser);
+
+        UUID requestHeaderUserId = savedUser.getId();
+        UUID userId = savedUser.getId();
+
+        Interest interest = InterestFixture.createInterest();
+        Interest savedInterest = interestRepository.save(interest);
+
+        Subscription subscription = SubscriptionFixture.createSubscription(savedUser,
+            savedInterest);
+        subscriptionRepository.save(subscription);
+
+        Article article = ArticleFixture.createArticle();
+        articleRepository.save(article);
+
+        Comment comment = CommentFixture.createComment(savedUser, article);
+        Comment otherComment = CommentFixture.createComment(savedOtherUser, article);
+        Comment savedComment = commentRepository.save(comment);
+        Comment savedOtherComment = commentRepository.save(otherComment);
+
+        CommentLike commentLike = CommentLikeFixture.createCommentLike(savedUser, savedComment);
+        CommentLike otherCommentLike = CommentLikeFixture.createCommentLike(savedUser,
+            savedOtherComment);
+        commentLikeRepository.save(commentLike);
+        commentLikeRepository.save(otherCommentLike);
+
+        Long beforeSubscriberCount
+            = interestRepository.findById(savedInterest.getId()).get().getSubscriberCount();
+        Long beforeCommentLikeCount
+            = commentRepository.findById(savedOtherComment.getId()).get().getLikeCount();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isNoContent());
+
+        Long afterSubscriberCount = interestRepository.findById(savedInterest.getId()).get()
+            .getSubscriberCount();
+        Long afterCommentLikeCount = commentRepository.findById(savedOtherComment.getId()).get()
+            .getLikeCount();
+
+        assertThat(afterSubscriberCount).isEqualTo(beforeSubscriberCount - 1);
+
+        assertThat(afterCommentLikeCount).isEqualTo(beforeCommentLikeCount - 1);
+
+        boolean userExists = userRepository.existsById(userId);
+        assertThat(userExists).isEqualTo(false);
+
+        boolean commentExists = commentRepository.existsById(savedComment.getId());
+        assertThat(commentExists).isEqualTo(false);
+
+    }
+
+    @Test
+    void 다른_사용자를_물리_삭제_시_403을_반환해야_한다() throws Exception {
+        // Given
+        User user = UserFixture.createUser();
+        User savedUser = userRepository.save(user);
+        UUID requestHeaderUserId = UUID.randomUUID();
+        UUID userId = savedUser.getId();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isForbidden());
+
+        User result = userRepository.findById(userId).orElseThrow();
+        assertThat(result.isDeleted()).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_사용자를_물리_삭제할_시_404를_반환해야_한다() throws Exception {
+        // Given
+        UUID requestHeaderUserId = UserFixture.getDefaultId();
+        UUID userId = UserFixture.getDefaultId();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 논리_삭제된_사용자를_물리_삭제할_시_정상적으로_연관된_객체를_삭제해야_한다() throws Exception {
+        // Given
+        User user = UserFixture.createUser();
+        user.setDeleted();
+        User savedUser = userRepository.save(user);
+
+        User otherUser = UserFixture.createUser("other@example.com", "otherUser", "Password123!");
+        User savedOtherUser = userRepository.save(otherUser);
+
+        UUID requestHeaderUserId = savedUser.getId();
+        UUID userId = savedUser.getId();
+
+        Interest interest = InterestFixture.createInterest();
+        Interest savedInterest = interestRepository.save(interest);
+
+        Subscription subscription = SubscriptionFixture.createSubscription(savedUser,
+            savedInterest);
+        subscriptionRepository.save(subscription);
+
+        Article article = ArticleFixture.createArticle();
+        articleRepository.save(article);
+
+        Comment comment = CommentFixture.createComment(savedUser, article);
+        Comment otherComment = CommentFixture.createComment(savedOtherUser, article);
+        Comment savedComment = commentRepository.save(comment);
+        Comment savedOtherComment = commentRepository.save(otherComment);
+
+        CommentLike commentLike = CommentLikeFixture.createCommentLike(savedUser, savedComment);
+        CommentLike otherCommentLike = CommentLikeFixture.createCommentLike(savedUser,
+            savedOtherComment);
+        commentLikeRepository.save(commentLike);
+        commentLikeRepository.save(otherCommentLike);
+
+        Long beforeSubscriberCount
+            = interestRepository.findById(savedInterest.getId()).get().getSubscriberCount();
+        Long beforeOtherCommentLikeCount =
+            commentRepository.findById(savedOtherComment.getId()).orElseThrow().getLikeCount();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isNoContent());
+
+        Long afterSubscriberCount = interestRepository.findById(savedInterest.getId())
+            .get()
+            .getSubscriberCount();
+        Long afterOtherCommentLikeCount = commentRepository.findById(savedOtherComment.getId())
+            .get()
+            .getLikeCount();
+
+        assertThat(afterSubscriberCount).isEqualTo(beforeSubscriberCount);
+        assertThat(afterOtherCommentLikeCount).isEqualTo(beforeOtherCommentLikeCount);
+
+        boolean userExists = userRepository.existsById(userId);
+        assertThat(userExists).isEqualTo(false);
+
+        boolean commentExists = commentRepository.existsById(savedComment.getId());
+        assertThat(commentExists).isEqualTo(false);
 
     }
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
@@ -389,35 +389,6 @@ public class UserIntegrationTest {
     }
 
     @Test
-    void 다른_사용자를_물리_삭제_시_403을_반환해야_한다() throws Exception {
-        // Given
-        User user = UserFixture.createUser();
-        User savedUser = userRepository.save(user);
-        UUID requestHeaderUserId = UUID.randomUUID();
-        UUID userId = savedUser.getId();
-
-        // When & Then
-        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
-                .requestAttr("userId", requestHeaderUserId))
-            .andExpect(status().isForbidden());
-
-        User result = userRepository.findById(userId).orElseThrow();
-        assertThat(result.isDeleted()).isFalse();
-    }
-
-    @Test
-    void 존재하지_않는_사용자를_물리_삭제할_시_404를_반환해야_한다() throws Exception {
-        // Given
-        UUID requestHeaderUserId = UserFixture.getDefaultId();
-        UUID userId = UserFixture.getDefaultId();
-
-        // When & Then
-        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
-                .requestAttr("userId", requestHeaderUserId))
-            .andExpect(status().isNotFound());
-    }
-
-    @Test
     void 논리_삭제된_사용자를_물리_삭제할_시_정상적으로_연관된_객체를_삭제해야_한다() throws Exception {
         // Given
         User user = UserFixture.createUser();
@@ -479,5 +450,34 @@ public class UserIntegrationTest {
 
     }
 
+
+    @Test
+    void 다른_사용자를_물리_삭제_시_403을_반환해야_한다() throws Exception {
+        // Given
+        User user = UserFixture.createUser();
+        User savedUser = userRepository.save(user);
+        UUID requestHeaderUserId = UUID.randomUUID();
+        UUID userId = savedUser.getId();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isForbidden());
+
+        User result = userRepository.findById(userId).orElseThrow();
+        assertThat(result.isDeleted()).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_사용자를_물리_삭제할_시_404를_반환해야_한다() throws Exception {
+        // Given
+        UUID requestHeaderUserId = UserFixture.getDefaultId();
+        UUID userId = UserFixture.getDefaultId();
+
+        // When & Then
+        mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .requestAttr("userId", requestHeaderUserId))
+            .andExpect(status().isNotFound());
+    }
 
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -337,7 +337,7 @@ public class UserServiceTest {
             then(interestRepository).should(times(subscriptions.size()))
                 .decrementSubscriberCount(any());
             then(commentRepository).should(times(commentLikes.size()))
-                .decreaseLikeCountAndDeleteById(any());
+                .decreaseLikeCountById(any());
         }
 
         @Test
@@ -435,7 +435,7 @@ public class UserServiceTest {
             then(interestRepository).should(times(subscriptions.size()))
                 .decrementSubscriberCount(any());
             then(commentRepository).should(times(commentLikes.size()))
-                .decreaseLikeCountAndDeleteById(any());
+                .decreaseLikeCountById(any());
             then(commentLikeRepository).should(times(comments.size())).deleteByCommentId(any());
             then(commentRepository).should(times(comments.size())).delete(any());
             then(commentLikeRepository).should().deleteByUserId(userId);
@@ -502,7 +502,7 @@ public class UserServiceTest {
             then(userRepository).should().findById(userId);
             then(commentRepository).should().findByAuthorId(userId);
             then(interestRepository).should(times(0)).decrementSubscriberCount(any());
-            then(commentRepository).should(times(0)).decreaseLikeCountAndDeleteById(any());
+            then(commentRepository).should(times(0)).decreaseLikeCountById(any());
             then(commentLikeRepository).should(times(comments.size())).deleteByCommentId(any());
             then(commentRepository).should(times(comments.size())).delete(any());
             then(commentLikeRepository).should().deleteByUserId(userId);

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -450,7 +450,7 @@ public class UserServiceTest {
             UUID requesterId = UUID.randomUUID();
 
             // When & Then
-            assertThatThrownBy(() -> userService.delete(requestUserId, requesterId))
+            assertThatThrownBy(() -> userService.deleteHard(requestUserId, requesterId))
                 .isInstanceOf(ForbiddenAccessException.class);
 
             then(userRepository).shouldHaveNoInteractions();
@@ -462,14 +462,13 @@ public class UserServiceTest {
             UUID userId = UserFixture.getDefaultId();
             UUID requesterId = UserFixture.getDefaultId();
 
-            given(userRepository.findByIdAndIsDeletedFalse(userId)).willThrow(
-                UserNotFoundException.class);
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
 
             // When & Then
-            assertThatThrownBy(() -> userService.delete(requesterId, userId))
+            assertThatThrownBy(() -> userService.deleteHard(requesterId, userId))
                 .isInstanceOf(UserNotFoundException.class);
 
-            then(userRepository).should().findByIdAndIsDeletedFalse(userId);
+            then(userRepository).should().findById(userId);
             then(userRepository).shouldHaveNoMoreInteractions();
             then(userMapper).shouldHaveNoInteractions();
         }


### PR DESCRIPTION
### 📌 작업 개요
- 사용자 물리 삭제 기능 구현
- 사용자 논리 삭제 메소드 수정 ( 좋아요 수 만 줄어들게 수정)

### ✅ 완료한 작업
- [x] 사용자 물리 삭제 기능 구현
- [x] 사용자 물리 삭제 테스트 코드 작성

### 🧪 테스트 결과
- 로컬 테스트 완료
- Postman 테스트 완료
- h2에서 확인 완료

### ⚠️ 기타 참고 사항
- 사용자 논리 삭제 시, 댓글 쪽에서 특정 내용 출력

### Related Issue

Closes #59 
