### PR TITLE
[feat] [MN-15] 댓글 좋아요 등록 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.controller;
 
 import com.sprint.mission.sb03monewteam1.controller.api.CommentApi;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -118,5 +119,21 @@ public class CommentController implements CommentApi {
         return ResponseEntity
             .status(HttpStatus.NO_CONTENT)
             .build();
+    }
+
+    @Override
+    @PostMapping(path = "/{commentId}/comment-likes")
+    public ResponseEntity<CommentLikeDto> like(
+        @PathVariable UUID commentId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId) {
+
+        log.info("댓글 좋아요 요청: commentId = {}, userId = {}", commentId, userId);
+
+        CommentLikeDto result = commentService.like(commentId, userId);
+
+        log.info("댓글 좋아요 완료: commentId = {}", commentId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(result);
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -60,7 +60,7 @@ public class CommentController implements CommentApi {
     ) {
         log.info("댓글 목록 조회 요청: articleId = {}, cursor = {}, after = {}, limit = {}, orderBy = {}, direction = {}", articleId, cursor, after, limit, orderBy, direction);
         CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-            articleId, cursor, after, limit, orderBy, direction
+            articleId, cursor, after, limit, orderBy, direction, userId
         );
         log.info("댓글 목록 조회 완료");
         log.info("조회된 댓글 수: {}", result.content().size());

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.controller.api;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -199,5 +200,37 @@ public interface CommentApi {
     })
     ResponseEntity<Void> deleteHard(
         @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId
+    );
+
+    @Operation(summary = "관심사 댓글 좋아요")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "댓글 좋아요 성공",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = CommentLikeDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<CommentLikeDto> like(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Monew-Request-User-ID") UUID userId
     );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/CommentDto.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/CommentDto.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 
-@Builder
+@Builder(toBuilder = true)
 public record CommentDto(
     UUID id,
     Instant createdAt,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/CommentLikeDto.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/CommentLikeDto.java
@@ -1,0 +1,21 @@
+package com.sprint.mission.sb03monewteam1.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CommentLikeDto(
+    UUID id,
+    UUID likedBy,
+    Instant createdAt,
+    UUID commentId,
+    UUID articleId,
+    UUID commentUserId,
+    String commentUserNickname,
+    String commentContent,
+    Long commentLikeCount,
+    Instant commentCreatedAt
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Comment.java
@@ -46,6 +46,16 @@ public class Comment extends BaseUpdatableEntity {
         }
     }
 
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 
     // 댓글 관련 예외
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 댓글입니다."),
 
     // 커서 기반 페이지네이션 관련 예외
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 커서 형식입니다."),

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentAlreadyLikedException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentAlreadyLikedException.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.sb03monewteam1.exception.comment;
+
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class CommentAlreadyLikedException extends CommentException {
+
+  public CommentAlreadyLikedException(UUID commentLikeId) {
+    super(ErrorCode.COMMENT_ALREADY_LIKED, Map.of("commentLikeID", String.valueOf(commentLikeId)));
+  }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentAlreadyLikedException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentAlreadyLikedException.java
@@ -6,7 +6,8 @@ import java.util.UUID;
 
 public class CommentAlreadyLikedException extends CommentException {
 
-  public CommentAlreadyLikedException(UUID commentLikeId) {
-    super(ErrorCode.COMMENT_ALREADY_LIKED, Map.of("commentLikeID", String.valueOf(commentLikeId)));
+  public CommentAlreadyLikedException(UUID commentId, UUID userId) {
+    super(ErrorCode.COMMENT_ALREADY_LIKED,
+        Map.of("commentId", String.valueOf(commentId), "userId", String.valueOf(userId)));
   }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/mapper/CommentLikeMapper.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/mapper/CommentLikeMapper.java
@@ -3,9 +3,18 @@ package com.sprint.mission.sb03monewteam1.mapper;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface CommentLikeMapper {
 
+    @Mapping(source = "user.id", target = "likedBy")
+    @Mapping(source = "comment.id", target = "commentId")
+    @Mapping(source = "comment.article.id", target = "articleId")
+    @Mapping(source = "comment.author.id", target = "commentUserId")
+    @Mapping(source = "comment.author.nickname", target = "commentUserNickname")
+    @Mapping(source = "comment.content", target = "commentContent")
+    @Mapping(source = "comment.likeCount", target = "commentLikeCount")
+    @Mapping(source = "comment.createdAt", target = "commentCreatedAt")
     CommentLikeDto toDto(CommentLike commentLike);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/mapper/CommentLikeMapper.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/mapper/CommentLikeMapper.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.sb03monewteam1.mapper;
+
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
+import com.sprint.mission.sb03monewteam1.entity.CommentLike;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CommentLikeMapper {
+
+    CommentLikeDto toDto(CommentLike commentLike);
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.repository;
 
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -17,4 +18,13 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     void deleteByCommentId(UUID commentId);
 
     boolean existsByCommentIdAndUserId(UUID commentId, UUID userId);
+
+    @Query("""
+            SELECT cl.comment.id FROM CommentLike cl 
+            WHERE cl.user.id = :userId AND cl.comment.id IN :commentIds
+           """)
+    Set<UUID> findLikedCommentIdsByUserIdAndCommentIds(
+        @Param("userId") UUID userId,
+        @Param("commentIds") List<UUID> commentIds
+    );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -16,5 +16,5 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
 
     void deleteByCommentId(UUID commentId);
 
-    Object existsByCommentIdAndUserId(UUID commentId, UUID userId);
+    boolean existsByCommentIdAndUserId(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -15,4 +15,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
     List<CommentLike> findAllByUserId(@Param("userId") UUID userId);
 
     void deleteByCommentId(UUID commentId);
+
+    Object existsByCommentIdAndUserId(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -14,10 +14,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
 
     Long countByArticleId(UUID articleId);
 
-    @Modifying
-    @Query("UPDATE Comment c SET c.likeCount = c.likeCount + 1 WHERE c.id = :commentId")
-    int increaseLikeCount(@Param("commentId") UUID commentId);
-
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Comment c "
         + "SET c.likeCount = CASE WHEN c.likeCount > 0 THEN c.likeCount - 1 ELSE 0 END,"

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/AllDataSeederRunner.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/AllDataSeederRunner.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.seeder;
 
 import jakarta.annotation.PostConstruct;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
@@ -15,7 +16,17 @@ public class AllDataSeederRunner {
 
     @PostConstruct
     public void runAllSeeders() {
-        seeders.forEach(DataSeeder::seed);
+        seeders.stream()
+            .sorted(Comparator.comparingInt(this::getOrder)) // Optional: @Order 기반
+            .forEach(DataSeeder::seed);
     }
 
+    private int getOrder(DataSeeder seeder) {
+        if (seeder instanceof UserDataSeeder) return 1;
+        if (seeder instanceof InterestDataSeeder) return 2;
+        if (seeder instanceof ArticleDataSeeder) return 3;
+        if (seeder instanceof CommentDataSeeder) return 4;
+        if (seeder instanceof CommentLikeDataSeeder) return 5;
+        return 99;
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/ArticleDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/ArticleDataSeeder.java
@@ -24,7 +24,7 @@ public class ArticleDataSeeder implements DataSeeder{
             articleRepository.save(article);
         }
 
-        log.info("샘플 기사 10개 생성 완료");
+        log.info("샘플 기사 5개 생성 완료");
     }
 
     private Article createArticle(String source, String sourceUrl, String title, String summary, Instant publishDate) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/ArticleDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/ArticleDataSeeder.java
@@ -1,0 +1,39 @@
+package com.sprint.mission.sb03monewteam1.seeder;
+
+import com.sprint.mission.sb03monewteam1.entity.Article;
+import com.sprint.mission.sb03monewteam1.repository.ArticleRepository;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class ArticleDataSeeder implements DataSeeder{
+
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public void seed() {
+
+        for (int i = 1; i <= 5; i++) {
+            Article article = createArticle("NAVER", "https://news.naver.com/article" + i, "샘플 기사" + i, "샘플 요약", Instant.now());
+            articleRepository.save(article);
+        }
+
+        log.info("샘플 기사 10개 생성 완료");
+    }
+
+    private Article createArticle(String source, String sourceUrl, String title, String summary, Instant publishDate) {
+        return Article.builder()
+            .source(source)
+            .sourceUrl(sourceUrl)
+            .title(title)
+            .summary(summary)
+            .publishDate(publishDate)
+            .build();
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentDataSeeder.java
@@ -1,0 +1,54 @@
+package com.sprint.mission.sb03monewteam1.seeder;
+
+import com.sprint.mission.sb03monewteam1.entity.Article;
+import com.sprint.mission.sb03monewteam1.entity.Comment;
+import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.repository.ArticleRepository;
+import com.sprint.mission.sb03monewteam1.repository.CommentRepository;
+import com.sprint.mission.sb03monewteam1.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class CommentDataSeeder implements DataSeeder{
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public void seed() {
+
+        User savedUser = userRepository.findByEmail("user1@example.com")
+            .orElseThrow(() -> new IllegalStateException("User not found in seeder"));
+
+        List<Article> articles = articleRepository.findAll();
+
+        for (Article article : articles) {
+            for (int i = 1; i <= 10; i++) {
+                Comment comment = createComment("[" + article.getTitle() + "] 댓글 " + i, savedUser, article);
+                article.increaseCommentCount(); // 댓글 수 증가
+                commentRepository.save(comment);
+            }
+        }
+
+        articleRepository.saveAll(articles);
+        log.info("샘플 댓글 10개 생성 완료");
+    }
+
+    private Comment createComment(String content, User user, Article article) {
+        return Comment.builder()
+            .content(content)
+            .author(user)
+            .article(article)
+            .build();
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentLikeDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentLikeDataSeeder.java
@@ -1,0 +1,56 @@
+package com.sprint.mission.sb03monewteam1.seeder;
+
+import com.sprint.mission.sb03monewteam1.entity.Comment;
+import com.sprint.mission.sb03monewteam1.entity.CommentLike;
+import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.repository.CommentLikeRepository;
+import com.sprint.mission.sb03monewteam1.repository.CommentRepository;
+import com.sprint.mission.sb03monewteam1.repository.UserRepository;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class CommentLikeDataSeeder implements DataSeeder {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public void seed() {
+        List<Comment> comments = commentRepository.findAll();
+        List<User> users = userRepository.findAll();
+
+        for (Comment comment : comments) {
+            // 유저 목록 섞기
+            Collections.shuffle(users);
+
+            // 1~3명 유저 선택
+            int likeCount = (int) (Math.random() * 3) + 1;
+            List<User> selectedUsers = users.subList(0, likeCount);
+
+            for (User user : selectedUsers) {
+                CommentLike like = createCommentLike(user, comment);
+                comment.increaseLikeCount(); // 좋아요 수 증가
+                commentLikeRepository.save(like);
+            }
+        }
+
+        commentRepository.saveAll(comments);
+        log.info("댓글 좋아요 시드 데이터 생성 완료 - 총 댓글 수: {}", comments.size());
+    }
+
+    private CommentLike createCommentLike(User user, Comment comment) {
+        return CommentLike.builder()
+            .user(user)
+            .comment(comment)
+            .build();
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentLikeDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/CommentLikeDataSeeder.java
@@ -33,10 +33,13 @@ public class CommentLikeDataSeeder implements DataSeeder {
             Collections.shuffle(users);
 
             // 1~3명 유저 선택
-            int likeCount = (int) (Math.random() * 3) + 1;
+            int likeCount = Math.min((int) (Math.random() * 3) + 1, users.size());
             List<User> selectedUsers = users.subList(0, likeCount);
 
             for (User user : selectedUsers) {
+                if (commentLikeRepository.existsByCommentIdAndUserId(comment.getId(), user.getId())) {
+                    continue;
+                }
                 CommentLike like = createCommentLike(user, comment);
                 comment.increaseLikeCount(); // 좋아요 수 증가
                 commentLikeRepository.save(like);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.sprint.mission.sb03monewteam1.service;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -26,4 +28,6 @@ public interface CommentService {
     Comment delete(UUID commentId, UUID userId);
 
     void deleteHard(UUID commentId);
+
+    CommentLikeDto like(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -20,7 +20,8 @@ public interface CommentService {
         Instant nextAfter,
         int size,
         String sortBy,
-        String sortDirection
+        String sortDirection,
+        UUID userId
     );
 
     CommentDto update(UUID commentId, UUID userId, CommentUpdateRequest commentUpdateRequest);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.service;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -209,6 +210,11 @@ public class CommentServiceImpl implements CommentService {
         commentRepository.deleteById(commentId);
 
         log.info("댓글 물리 삭제 완료 : 댓글 ID = {}", commentId);
+    }
+
+    @Override
+    public CommentLikeDto like(UUID commentId, UUID userId) {
+        return null;
     }
 
     private void validateAuthor(Comment comment, UUID userId) {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -15,11 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentException;
@@ -28,6 +30,7 @@ import com.sprint.mission.sb03monewteam1.exception.comment.UnauthorizedCommentAc
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
 import com.sprint.mission.sb03monewteam1.fixture.ArticleFixture;
 import com.sprint.mission.sb03monewteam1.fixture.CommentFixture;
+import com.sprint.mission.sb03monewteam1.fixture.CommentLikeFixture;
 import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.service.CommentService;
 import java.time.Instant;
@@ -598,6 +601,58 @@ public class CommentControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(ErrorCode.COMMENT_NOT_FOUND.name()))
                 .andExpect(jsonPath("$.message").exists());
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 좋아요 테스트")
+    class CommentLikeTest {
+
+        @Test
+        void 댓글에_좋아요를_누르면_200과_좋아요DTO_좋아요수가_1증가되어야_한다() throws Exception {
+
+            // given
+            UUID commentId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(UUID.randomUUID());
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
+
+            Comment comment = CommentFixture.createComment("좋아요 테스트", user, article);
+            ReflectionTestUtils.setField(comment, "id", commentId);
+            CommentLike commentLike = CommentLikeFixture.createCommentLike(user, comment);
+            CommentLikeDto responseDto = CommentLikeFixture.createCommentLikeDto(commentLike);
+
+            given(commentService.like(eq(commentId), eq(userId))).willReturn(responseDto);
+
+            // when & then
+            mockMvc.perform(post("/api/comments/{commentId}/like", commentId)
+                    .header("Monew-Request-User-ID", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.likedBy").value(userId.toString()))
+                .andExpect(jsonPath("$.commentId").value(commentId.toString()))
+                .andExpect(jsonPath("$.commentLikeCount").value(1L))
+                .andExpect(jsonPath("$.articleId").value(article.getId().toString()))
+                .andExpect(jsonPath("$.commentUserId").value(userId.toString()))
+                .andExpect(jsonPath("$.commentUserNickname").value(user.getNickname()))
+                .andExpect(jsonPath("$.commentContent").value(comment.getContent()))
+                .andExpect(jsonPath("$.commentCreatedAt").exists());
+        }
+
+        @Test
+        void 존재하지_않는_댓글에_좋아요를_요청시_404가_반환되어야_한다() throws Exception {
+
+            // given
+            UUID commentId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            given(commentService.like(eq(commentId), eq(userId)))
+                .willThrow(new CommentNotFoundException(commentId));
+
+            // when & then
+            mockMvc.perform(post("/api/comments/{commentId}/like", commentId)
+                    .header("Monew-Request-User-ID", userId.toString()))
+                .andExpect(status().isNotFound());
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -620,13 +620,14 @@ public class CommentControllerTest {
 
             Comment comment = CommentFixture.createComment("좋아요 테스트", user, article);
             ReflectionTestUtils.setField(comment, "id", commentId);
+            ReflectionTestUtils.setField(comment, "createdAt", Instant.now());
             CommentLike commentLike = CommentLikeFixture.createCommentLike(user, comment);
-            CommentLikeDto responseDto = CommentLikeFixture.createCommentLikeDto(commentLike);
+            CommentLikeDto responseDto = CommentLikeFixture.createCommentLikeDtoWithLikeCount(commentLike,1L);
 
             given(commentService.like(eq(commentId), eq(userId))).willReturn(responseDto);
 
             // when & then
-            mockMvc.perform(post("/api/comments/{commentId}/like", commentId)
+            mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
                     .header("Monew-Request-User-ID", userId.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.likedBy").value(userId.toString()))
@@ -650,7 +651,7 @@ public class CommentControllerTest {
                 .willThrow(new CommentNotFoundException(commentId));
 
             // when & then
-            mockMvc.perform(post("/api/comments/{commentId}/like", commentId)
+            mockMvc.perform(post("/api/comments/{commentId}/comment-likes", commentId)
                     .header("Monew-Request-User-ID", userId.toString()))
                 .andExpect(status().isNotFound());
         }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -160,9 +160,12 @@ public class CommentControllerTest {
         void 댓글을_조회하면_200과_댓글목록이_반환된다() throws Exception {
 
             // given
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
-            Article article = ArticleFixture.createArticle();
-            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            ReflectionTestUtils.setField(user, "id", userId);
+
+            UUID articleId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(articleId);
             String sortBy = "createdAt";
             String sortDirection = "DESC";
             int totalCount = 10;
@@ -189,11 +192,12 @@ public class CommentControllerTest {
                 .hasNext(true)
                 .build();
 
-            given(commentService.getCommentsWithCursorBySort(eq(null), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection)))
+            given(commentService.getCommentsWithCursorBySort(eq(articleId), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId)))
                 .willReturn(result);
 
             // when & then
             mockMvc.perform(get("/api/comments")
+                    .param("articleId", articleId.toString())
                     .param("orderBy", sortBy)
                     .param("direction", sortDirection)
                     .param("limit", String.valueOf(pageSize))
@@ -212,9 +216,12 @@ public class CommentControllerTest {
         @Test
         void 커서가_있으면_커서_이후의_댓글만_조회된다() throws Exception {
             // given
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
-            Article article = ArticleFixture.createArticle();
-            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            ReflectionTestUtils.setField(user, "id", userId);
+
+            UUID articleId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(articleId);
             String sortBy = "createdAt";
             String sortDirection = "DESC";
             int totalCount = 10;
@@ -245,11 +252,12 @@ public class CommentControllerTest {
                 .hasNext(true)
                 .build();
 
-            given(commentService.getCommentsWithCursorBySort(eq(null), eq(cursor), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection)))
+            given(commentService.getCommentsWithCursorBySort(eq(articleId), eq(cursor), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId)))
                 .willReturn(result);
 
             // when & then
             mockMvc.perform(get("/api/comments")
+                    .param("articleId", articleId.toString())
                     .param("cursor", cursor)
                     .param("orderBy", sortBy)
                     .param("direction", sortDirection)
@@ -276,7 +284,7 @@ public class CommentControllerTest {
             int pageSize = 5;
 
             given(commentService.getCommentsWithCursorBySort(
-                eq(invalidArticleId), any(), any(), eq(pageSize), eq(sortBy), eq(sortDirection))
+                eq(invalidArticleId), any(), any(), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId))
             ).willThrow(new CommentException(ErrorCode.ARTICLE_NOT_FOUND));
 
             // when & then
@@ -301,7 +309,7 @@ public class CommentControllerTest {
             int pageSize = 5;
 
             given(commentService.getCommentsWithCursorBySort(
-                eq(null), eq(null), eq(null), eq(pageSize), eq(invalidSortBy), eq(sortDirection)
+                eq(null), eq(null), eq(null), eq(pageSize), eq(invalidSortBy), eq(sortDirection), eq(userId)
             )).willThrow(new InvalidSortOptionException(ErrorCode.INVALID_SORT_FIELD));
 
             // when & then
@@ -324,7 +332,7 @@ public class CommentControllerTest {
             String invalidDirection = "INVALID";
 
             given(commentService.getCommentsWithCursorBySort(
-                eq(null), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(invalidDirection)
+                eq(null), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(invalidDirection), eq(userId)
             )).willThrow(new InvalidSortOptionException(ErrorCode.INVALID_SORT_DIRECTION));
 
             mockMvc.perform(get("/api/comments")

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
@@ -58,6 +58,21 @@ public class CommentLikeFixture {
             .build();
     }
 
+    public static CommentLikeDto createCommentLikeDtoWithLikeCount(CommentLike commentLike, Long likeCount) {
+        return CommentLikeDto.builder()
+            .id(commentLike.getId())
+            .likedBy(commentLike.getUser().getId())
+            .createdAt(commentLike.getCreatedAt())
+            .commentId(commentLike.getComment().getId())
+            .articleId(commentLike.getComment().getArticle().getId())
+            .commentUserId(commentLike.getComment().getAuthor().getId())
+            .commentUserNickname(commentLike.getUser().getNickname())
+            .commentContent(commentLike.getComment().getContent())
+            .commentLikeCount(likeCount)
+            .commentCreatedAt(commentLike.getComment().getCreatedAt())
+            .build();
+    }
+
     public static UUID getDefaultCommentLikeId() {
         return DEFAULT_COMMENT_LIKE_ID;
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
@@ -1,8 +1,10 @@
 package com.sprint.mission.sb03monewteam1.fixture;
 
+import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.User;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -39,6 +41,21 @@ public class CommentLikeFixture {
             commentLikes.add(createCommentLike(user, comment));
         }
         return commentLikes;
+    }
+
+    public static CommentLikeDto createCommentLikeDto(CommentLike commentLike) {
+        return CommentLikeDto.builder()
+            .id(commentLike.getId())
+            .likedBy(commentLike.getUser().getId())
+            .createdAt(commentLike.getCreatedAt())
+            .commentId(commentLike.getComment().getId())
+            .articleId(commentLike.getComment().getArticle().getId())
+            .commentUserId(commentLike.getComment().getAuthor().getId())
+            .commentUserNickname(commentLike.getUser().getNickname())
+            .commentContent(commentLike.getComment().getContent())
+            .commentLikeCount(commentLike.getComment().getLikeCount())
+            .commentCreatedAt(commentLike.getComment().getCreatedAt())
+            .build();
     }
 
     public static UUID getDefaultCommentLikeId() {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentLikeFixture.java
@@ -51,7 +51,7 @@ public class CommentLikeFixture {
             .commentId(commentLike.getComment().getId())
             .articleId(commentLike.getComment().getArticle().getId())
             .commentUserId(commentLike.getComment().getAuthor().getId())
-            .commentUserNickname(commentLike.getUser().getNickname())
+            .commentUserNickname(commentLike.getComment().getAuthor().getNickname())
             .commentContent(commentLike.getComment().getContent())
             .commentLikeCount(commentLike.getComment().getLikeCount())
             .commentCreatedAt(commentLike.getComment().getCreatedAt())

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -177,7 +177,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
 
             int pageSize = 5;
             String sortBy = "createdAt";
@@ -204,7 +206,7 @@ public class CommentServiceTest {
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection
+                articleId, null, null, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -233,7 +235,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
             int pageSize = 5;
             String sortBy = "likeCount";
             String sortDirection = "DESC";
@@ -259,7 +263,7 @@ public class CommentServiceTest {
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection
+                articleId, null, null, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -278,7 +282,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
             int pageSize = 5;
             String sortBy = "createdAt";
             String sortDirection = "DESC";
@@ -309,7 +315,7 @@ public class CommentServiceTest {
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, cursor.toString(), after, pageSize, sortBy, sortDirection
+                articleId, cursor.toString(), after, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -335,7 +341,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
             int pageSize = 5;
             String sortBy = "createdAt";
             String sortDirection = "DESC";
@@ -364,7 +372,7 @@ public class CommentServiceTest {
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, nextCursor.toString(), nextAfter, pageSize, sortBy, sortDirection
+                articleId, nextCursor.toString(), nextAfter, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -390,6 +398,7 @@ public class CommentServiceTest {
         void 댓글이_없는_기사를_조회하면_빈_리스트를_반환한다() {
 
             // given
+            UUID userId = UUID.randomUUID();
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
             int pageSize = 5;
@@ -404,7 +413,7 @@ public class CommentServiceTest {
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection
+                articleId, null, null, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -423,7 +432,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
             int pageSize = 5;
             String sortBy = "createdAt";
             String sortDirection = "DESC";
@@ -435,10 +446,14 @@ public class CommentServiceTest {
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(commentList.subList(0, pageSize));
             given(commentRepository.countByArticleId(articleId)).willReturn(5L);
+            given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
+                Comment comment = invocation.getArgument(0);
+                return CommentFixture.createCommentDto(comment);
+            });
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection
+                articleId, null, null, pageSize, sortBy, sortDirection, userId
             );
 
             // then
@@ -454,7 +469,9 @@ public class CommentServiceTest {
             // given
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
             String invalidCursor = "invalid-value";
             int pageSize = 5;
             String sortBy = "createdAt";
@@ -466,7 +483,7 @@ public class CommentServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection)
+                commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection, userId)
             ).isInstanceOf(InvalidCursorException.class)
                 .hasMessageContaining(ErrorCode.INVALID_CURSOR_DATE.getMessage());
         }
@@ -475,6 +492,7 @@ public class CommentServiceTest {
         void 유효하지_않은_페이지_크기로_조회시_예외가_발생한다() {
 
             // given
+            UUID userId = UUID.randomUUID();
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
             int invalidPageSize = -1;
@@ -485,7 +503,7 @@ public class CommentServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, invalidPageSize, sortBy, sortDirection)
+                commentService.getCommentsWithCursorBySort(articleId, null, null, invalidPageSize, sortBy, sortDirection, userId)
             ).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("페이지 크기는 1 이상이어야 합니다");
         }
@@ -494,6 +512,7 @@ public class CommentServiceTest {
         void 잘못된_정렬기준_입력시_예외가_발생한다() {
 
             // given
+            UUID userId = UUID.randomUUID();
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
             String invalidSort = "unknownField"; // 허용되지 않은 정렬 기준
@@ -504,7 +523,7 @@ public class CommentServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, invalidSort, sortDirection)
+                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, invalidSort, sortDirection, userId)
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_FIELD.getMessage());
@@ -514,6 +533,7 @@ public class CommentServiceTest {
         void 잘못된_정렬방향_입력시_예외가_발생한다() {
 
             // given
+            UUID userId = UUID.randomUUID();
             UUID articleId = UUID.randomUUID();
             Article article = ArticleFixture.createArticleWithId(articleId);
             int pageSize = 5;
@@ -524,7 +544,7 @@ public class CommentServiceTest {
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, sortBy, invalidSortDirection)
+                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, sortBy, invalidSortDirection, userId)
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_DIRECTION.getMessage());


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 좋아요 등록 기능 구현
- CommentDto에 likedByMe 필드 설정 로직 추가
- 댓글 목록 조회 및 수정 응답 로직과 관련 테스트 코드 수정
- 댓글, 좋아요, 뉴스 기사 Seeder 구현

### ✅ 완료한 작업
- [x] 댓글 좋아요 등록 로직 구현
- [x] 컨트롤러/서비스 테스트 코드 작성
- [x]  likedByMe 값 설정 로직 적용 (CommentDto)
- [x] 댓글 목록 조회, 댓글 수정 기능에 적용
- [x] 관련 테스트 코드 수정 및 검증

### 🧪 테스트 결과
- 테스트 코드 통과
- 로컬 환경 테스트 완료

### ⚠️ 기타 참고 사항
- CommentDto의 변경으로 인해 기존 조회/수정 로직과 테스트 코드 관련 부분을 모두 수정했습니다.
따라서 커밋이 깔끔하지 못할 수 있으니 양해 부탁드립니다!
- 댓글 Seeder 생성시 뉴스기사 더미데이터가 필요하여 우선 만들어두었는데, 추후 수정이 필요하시다면 수정해서 사용해야 할 것 같습니다!
- Seeder 실행순서를 명시해두었습니다! 
(댓글쪽에서 user,article 더미데이터를 생성하려하니 에러가 발생해서, 실행순서대로 seeder를 실행해, 그 데이터를 활용하는 방식으로 구현)

### Related Issue

Closes #66 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 댓글에 좋아요를 누를 수 있는 기능이 추가되었습니다.
  * 댓글 목록 조회 시, 내가 좋아요를 누른 댓글 여부가 표시됩니다.

* **버그 수정**
  * 댓글 좋아요 중복 시도 시, 알맞은 에러 메시지가 제공됩니다.

* **테스트**
  * 댓글 좋아요 기능 및 예외 상황에 대한 테스트가 추가되었습니다.

* **데이터 시더**
  * 개발 환경에서 샘플 기사, 댓글, 댓글 좋아요 데이터를 자동으로 생성하는 기능이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->