### PR TITLE
[feat] [MN-60] 관심사 조회 시 구독 여부 체크 추가

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
@@ -37,6 +37,7 @@ public class InterestController implements InterestApi {
 
     @GetMapping
     public ResponseEntity<CursorPageResponse<InterestDto>> getInterests(
+        @RequestHeader("Monew-Request-User-ID") UUID userId,
         @RequestParam(defaultValue = "") String keyword,
         @RequestParam(defaultValue = "") String cursor,
         @RequestParam(defaultValue = "10") int limit,
@@ -44,11 +45,11 @@ public class InterestController implements InterestApi {
         @RequestParam(defaultValue = "DESC") String direction)
     {
 
-        log.info("관심사 조회 요청: keyword: {}, cursor: {}, limit: {}, orderBy: {}, direction: {}",
-            keyword, cursor, limit, orderBy, direction);
+        log.info("관심사 조회 요청: userId: {}. keyword: {}, cursor: {}, limit: {}, orderBy: {}, direction: {}",
+            userId, keyword, cursor, limit, orderBy, direction);
 
         CursorPageResponse<InterestDto> response = interestService.getInterests(
-            keyword, cursor, limit, orderBy, direction);
+            userId, keyword, cursor, limit, orderBy, direction);
 
         log.info("관심사 조회 완료: {}", response);
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/InterestApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/InterestApi.java
@@ -93,6 +93,7 @@ public interface InterestApi {
         )
     })
     ResponseEntity<CursorPageResponse<InterestDto>> getInterests(
+        @RequestHeader("Monew-Request-User-ID") UUID userId,
         @RequestParam(defaultValue = "") String keyword,
         @RequestParam(defaultValue = "") String cursor,
         @RequestParam(defaultValue = "10") int limit,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/InterestRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/InterestRepositoryImpl.java
@@ -70,10 +70,13 @@ public class InterestRepositoryImpl implements InterestRepositoryCustom {
         BooleanBuilder builder = new BooleanBuilder();
         addSearchConditions(builder, keyword);
 
-        return jpaQueryFactory
-            .selectFrom(qInterest)
+        Long count = jpaQueryFactory
+            .select(qInterest.count())
+            .from(qInterest)
             .where(builder)
-            .fetchCount();
+            .fetchOne();
+
+        return count != null ? count : 0L;
     }
 
     private void addSearchConditions(BooleanBuilder builder, String keyword) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
@@ -1,9 +1,7 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
-import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import java.util.List;
-import com.sprint.mission.sb03monewteam1.entity.User;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +11,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
-    boolean existsByUserAndInterest(User user, Interest interest);
+    boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
 
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.interest WHERE s.user.id = :userId")
     List<Subscription> findAllByUserId(@Param("userId") UUID userId);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/SubscriptionRepository.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
 
-    boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
-
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.interest WHERE s.user.id = :userId")
     List<Subscription> findAllByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/AllDataSeederRunner.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/AllDataSeederRunner.java
@@ -1,7 +1,6 @@
 package com.sprint.mission.sb03monewteam1.seeder;
 
 import jakarta.annotation.PostConstruct;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -11,11 +10,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AllDataSeederRunner {
 
-    private final List<DataSeeder> seeders;
+    private final UserDataSeeder userDataSeeder;
+    private final InterestDataSeeder interestDataSeeder;
+    private final SubscriptionDataSeeder subscriptionDataSeeder;
 
     @PostConstruct
     public void runAllSeeders() {
-        seeders.forEach(DataSeeder::seed);
-    }
+        userDataSeeder.seed();
 
+        interestDataSeeder.seed();
+
+        subscriptionDataSeeder.seed();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/SubscriptionDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/SubscriptionDataSeeder.java
@@ -1,0 +1,67 @@
+package com.sprint.mission.sb03monewteam1.seeder;
+
+import com.sprint.mission.sb03monewteam1.entity.Interest;
+import com.sprint.mission.sb03monewteam1.entity.Subscription;
+import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.repository.SubscriptionRepository;
+import com.sprint.mission.sb03monewteam1.repository.UserRepository;
+import com.sprint.mission.sb03monewteam1.repository.InterestRepository;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Random;
+
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class SubscriptionDataSeeder implements DataSeeder {
+
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserRepository userRepository;
+    private final InterestRepository interestRepository;
+
+    @Override
+    @Transactional
+    public void seed() {
+        if (subscriptionRepository.count() > 0) {
+            log.info("SubscriptionDataSeeder: 구독 데이터가 이미 존재하여 시드를 실행하지 않습니다.");
+            return;
+        }
+
+        List<User> users = userRepository.findAll();
+        List<Interest> interests = interestRepository.findAll();
+
+        if (users.isEmpty() || interests.isEmpty()) {
+            log.warn("SubscriptionDataSeeder: 사용자가 없거나 관심사가 없습니다.");
+            return;
+        }
+
+        List<Subscription> subscriptions = createSubscriptions(users, interests);
+
+        subscriptionRepository.saveAll(subscriptions);
+
+        log.info("SubscriptionDataSeeder: 총 {}개의 구독 데이터가 추가되었습니다.", subscriptions.size());
+    }
+
+    private List<Subscription> createSubscriptions(List<User> users, List<Interest> interests) {
+        Random random = new Random();
+        List<Subscription> subscriptions = new ArrayList<>();
+
+        for (User user : users) {
+            int subscriptionCount = 40;
+            for (int i = 0; i < subscriptionCount; i++) {
+                Interest randomInterest = interests.get(random.nextInt(interests.size()));
+                Subscription subscription = new Subscription(randomInterest, user);
+                subscriptions.add(subscription);
+            }
+        }
+
+        return subscriptions;
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/SubscriptionDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/SubscriptionDataSeeder.java
@@ -7,6 +7,8 @@ import com.sprint.mission.sb03monewteam1.repository.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.UserRepository;
 import com.sprint.mission.sb03monewteam1.repository.InterestRepository;
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -52,11 +54,16 @@ public class SubscriptionDataSeeder implements DataSeeder {
     private List<Subscription> createSubscriptions(List<User> users, List<Interest> interests) {
         Random random = new Random();
         List<Subscription> subscriptions = new ArrayList<>();
+        Set<String> createdPairs = new HashSet<>();
 
         for (User user : users) {
             int subscriptionCount = 40;
             for (int i = 0; i < subscriptionCount; i++) {
                 Interest randomInterest = interests.get(random.nextInt(interests.size()));
+                String key = user.getId() + ":" + randomInterest.getId();
+                if (!createdPairs.add(key)) {
+                    continue;
+                }
                 Subscription subscription = new Subscription(randomInterest, user);
                 subscriptions.add(subscription);
             }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
@@ -11,6 +11,7 @@ public interface InterestService {
     InterestDto create(InterestRegisterRequest request);
 
     CursorPageResponse<InterestDto> getInterests(
+        UUID userId,
         String searchKeyword,
         String cursor,
         int limit,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -22,7 +22,9 @@ import com.sprint.mission.sb03monewteam1.repository.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.UserRepository;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -105,11 +107,15 @@ public class InterestServiceImpl implements InterestService {
         List<Interest> interests = interestRepository.searchByKeywordOrName(
             keyword, cursorValue, limit + 1, orderBy, direction);
 
+        Set<UUID> subscribedInterestIds = new HashSet<>();
+        subscriptionRepository.findAllByUserId(userId)
+            .forEach(subscription -> subscribedInterestIds.add(subscription.getInterest().getId()));
+
         List<InterestDto> content = interests.stream()
             .map(interest -> {
-                boolean isSubscribed = subscriptionRepository.existsByUserIdAndInterestId(userId, interest.getId());
+                boolean isSubscribed = subscribedInterestIds.contains(interest.getId());
 
-                InterestDto interestDto = InterestDto.builder()
+                return InterestDto.builder()
                     .id(interest.getId())
                     .name(interest.getName())
                     .keywords(
@@ -122,7 +128,6 @@ public class InterestServiceImpl implements InterestService {
                     .subscriberCount(interest.getSubscriberCount())
                     .subscribedByMe(isSubscribed)
                     .build();
-                return interestDto;
             })
             .collect(Collectors.toList());
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
@@ -176,17 +176,20 @@ class InterestControllerTest {
         @Test
         void 관심사_목록을_조회하면_관심사_목록을_반환한다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
+
             List<InterestDto> interestDtos = InterestFixture.createInterestDtoList();
             CursorPageResponse<InterestDto> responseDto = new CursorPageResponse<>(
                 interestDtos, null, null, 10, 4L, false
             );
 
             given(interestService.getInterests(
-                anyString(), anyString(), anyInt(), anyString(), anyString()))
+                any(UUID.class),anyString(), anyString(), anyInt(), anyString(), anyString()))
                 .willReturn(responseDto);
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -205,6 +208,8 @@ class InterestControllerTest {
         @Test
         void 관심사를_이름으로_검색하면_부분일치하는_관심사만_조회된다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
+
             List<InterestDto> interestDtos = List.of(
                 InterestFixture.createInterestResponseDto("football", List.of("club", "sport")),
                 InterestFixture.createInterestResponseDto("soccer", List.of("ball", "sports"))
@@ -214,11 +219,12 @@ class InterestControllerTest {
             );
 
             given(interestService.getInterests(
-                eq("football"), anyString(), eq(10), eq("name"), eq("asc")))
+                any(UUID.class), eq("football"), anyString(), eq(10), eq("name"), eq("asc")))
                 .willReturn(responseDto);
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", "football")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -235,6 +241,8 @@ class InterestControllerTest {
         @Test
         void 관심사를_구독자수로_정렬하여_반환한다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
+
             List<InterestDto> interestDtos = Arrays.asList(
                 InterestDto.builder().id(UUID.randomUUID()).name("soccer").subscriberCount(200L)
                     .build(),
@@ -256,11 +264,12 @@ class InterestControllerTest {
                 .build();
 
             given(interestService.getInterests(
-                anyString(), anyString(), eq(10), eq("subscriberCount"), eq("desc")))
+                any(UUID.class), anyString(), anyString(), eq(10), eq("subscriberCount"), eq("desc")))
                 .willReturn(responseDto);
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("orderBy", "subscriberCount")
@@ -281,6 +290,7 @@ class InterestControllerTest {
         @Test
         void 관심사를_이름순으로_정렬하여_반환한다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
             List<InterestDto> interestDtos = Arrays.asList(
                 InterestDto.builder().id(UUID.randomUUID()).name("aesthetic").build(),
                 InterestDto.builder().id(UUID.randomUUID()).name("beauty").build(),
@@ -298,11 +308,12 @@ class InterestControllerTest {
                 .build();
 
             given(interestService.getInterests(
-                anyString(), anyString(), eq(10), eq("name"), eq("asc")))
+                any(UUID.class), anyString(), anyString(), eq(10), eq("name"), eq("asc")))
                 .willReturn(responseDto);
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("orderBy", "name")
@@ -319,15 +330,17 @@ class InterestControllerTest {
         @Test
         void 잘못된_커서_형식인_경우_400을_반환한다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
             String invalidCursor = "invalidCursor";
             String keyword = "soccer";
             int limit = 10;
 
-            given(interestService.getInterests(any(), any(), anyInt(), any(), any()))
+            given(interestService.getInterests(any(UUID.class), any(), any(), anyInt(), any(), any()))
                 .willThrow(new InvalidCursorException("잘못된 커서 형식입니다."));
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", keyword)
                     .param("cursor", invalidCursor)
                     .param("limit", String.valueOf(limit))
@@ -341,15 +354,17 @@ class InterestControllerTest {
         @Test
         void 잘못된_정렬_기준인_경우_400을_반환한다() throws Exception {
             // Given
+            UUID userId = UUID.randomUUID();
             String invalidOrderBy = "invalidOrder";
             String keyword = "soccer";
             int limit = 10;
 
-            given(interestService.getInterests(any(), any(), anyInt(), any(), any()))
+            given(interestService.getInterests(any(UUID.class), any(), any(), anyInt(), any(), any()))
                 .willThrow(new InvalidSortOptionException("지원하지 않는 정렬 필드입니다."));
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", userId.toString())
                     .param("keyword", keyword)
                     .param("cursor", "")
                     .param("limit", String.valueOf(limit))

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
@@ -155,6 +155,8 @@ class InterestIntegrationTest {
     @DisplayName("관심사 조회 테스트")
     class InterestReadTests {
 
+        private User testUser;
+
         @BeforeEach
         void setUp() {
             Interest interest1 = Interest.builder()
@@ -199,12 +201,21 @@ class InterestIntegrationTest {
 
             interestRepository.saveAll(List.of(interest1, interest2, interest3, interest4));
             interestKeywordRepository.saveAll(List.of(keyword1, keyword2, keyword3, keyword4));
+
+
+            testUser = User.builder()
+                .nickname("testUser")
+                .email("testuser@example.com")
+                .password("password1234*")
+                .build();
+            userRepository.save(testUser);
         }
 
         @Test
         void 관심사_목록을_조회하면_관심사_목록을_반환한다() throws Exception {
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -220,6 +231,7 @@ class InterestIntegrationTest {
         void 관심사_이름으로_검색하면_부분일치하는_관심사만_조회된다() throws Exception {
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", "soccer")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -236,6 +248,7 @@ class InterestIntegrationTest {
         void 관심사_이름순으로_정렬하면_이름순으로_정렬된_목록을_반환한다() throws Exception {
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -253,6 +266,7 @@ class InterestIntegrationTest {
         void 관심사_구독자순으로_내림차순으로_정렬하면_구독자순으로_내림차순으로_정렬된_목록을_반환한다() throws Exception {
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", "")
                     .param("cursor", "")
                     .param("limit", "10")
@@ -276,6 +290,7 @@ class InterestIntegrationTest {
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", keyword)
                     .param("cursor", "")
                     .param("limit", String.valueOf(limit))
@@ -298,6 +313,7 @@ class InterestIntegrationTest {
 
             // When & Then
             mockMvc.perform(get("/api/interests")
+                    .header("Monew-Request-User-ID", testUser.getId())
                     .param("keyword", keyword)
                     .param("cursor", cursor)
                     .param("limit", String.valueOf(limit))

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -154,16 +154,22 @@ class InterestServiceTest {
             Interest interest2 = Interest.builder().name("soccer").subscriberCount(200L).build();
 
             List<Interest> interests = Arrays.asList(interest2, interest1);
-            List<InterestDto> interestDtos = Arrays.asList(
-                InterestDto.builder().name("soccer").subscriberCount(200L).build(),
-                InterestDto.builder().name("aesthetic").subscriberCount(150L).build()
-            );
 
             when(interestRepository.searchByKeywordOrName(null, null, limit + 1, orderBy, direction))
                 .thenReturn(interests);
 
-            when(subscriptionRepository.existsByUserIdAndInterestId(user.getId(), interest1.getId())).thenReturn(true);
-            when(subscriptionRepository.existsByUserIdAndInterestId(user.getId(), interest2.getId())).thenReturn(false);
+            Subscription subscription1 = Subscription.builder()
+                .user(user)
+                .interest(interest1)
+                .build();
+
+            Subscription subscription2 = Subscription.builder()
+                .user(user)
+                .interest(interest2)
+                .build();
+
+            when(subscriptionRepository.findAllByUserId(user.getId()))
+                .thenReturn(Arrays.asList(subscription1, subscription2));
 
             // When
             CursorPageResponse<InterestDto> result = interestService.getInterests(user.getId(), null, null, limit, orderBy, direction);
@@ -175,12 +181,8 @@ class InterestServiceTest {
             assertThat(result.hasNext()).isFalse();
 
             verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy, direction);
-            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest1.getId());
-            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest2.getId());
+            verify(subscriptionRepository).findAllByUserId(user.getId());
         }
-
-
-
 
         @Test
         void 관심사를_조회하면_키워드로_검색한다() {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -174,9 +174,9 @@ class InterestServiceTest {
             assertThat(result.content().get(1).name()).isEqualTo("aesthetic");
             assertThat(result.hasNext()).isFalse();
 
-            verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy, direction); // searchByKeywordOrName 메서드 호출 확인
-            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest1.getId());  // 구독 체크 2번 호출 확인
-            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest2.getId());  // 구독 체크 2번 호출 확인
+            verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy, direction);
+            verify(subscriptionRepository).existsByUserIdAndInterestId(user.getId(), interest1.getId());
+            verify(subscriptionRepository).existsByUserIdAndInterestId(user.getId(), interest2.getId());
         }
 
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -175,8 +175,8 @@ class InterestServiceTest {
             assertThat(result.hasNext()).isFalse();
 
             verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy, direction);
-            verify(subscriptionRepository).existsByUserIdAndInterestId(user.getId(), interest1.getId());
-            verify(subscriptionRepository).existsByUserIdAndInterestId(user.getId(), interest2.getId());
+            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest1.getId());
+            verify(subscriptionRepository, times(2)).existsByUserIdAndInterestId(user.getId(), interest2.getId());
         }
 
 


### PR DESCRIPTION
### 📌 작업 개요
- 관심사 목록 조회 시 사용자의 구독 여부 반영 로직 추가
- Subscription seeder 추가
- deprecated 된 메서드 수정

### ✅ 완료한 작업
- 관심사 목록 조회 시 사용자 구독 여부 반영 구현
- 테스트 코드 수정 및 통과

### 🧪 테스트 결과
- 로컬 테스트 완료
- Postman 테스트 완료

### ⚠️ 기타 참고 사항
- Subscription data seeder 에서 사용자, 관심사 repository의 데이터를 이용하기 때문에 각 seeder가 순차적으로 실행되도록 수정함

### Related Issue

Closes #69 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관심사 목록 조회 시 사용자 식별자(`Monew-Request-User-ID` 헤더)를 필수로 입력하도록 변경되었습니다.
  * 관심사 목록 응답에 각 관심사별로 사용자가 구독 중인지 여부가 표시됩니다.
  * 개발 환경에서 구독 데이터 시더가 추가되어 테스트 데이터 생성이 용이해졌습니다.

* **버그 수정**
  * 관심사 및 구독 관련 일부 조회 로직이 개선되었습니다.

* **테스트**
  * 사용자 식별자 기반의 관심사 조회 및 구독 여부 확인 테스트가 추가 및 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->