### PR TITLE
[feat] [MN-44] 뉴스 기사 물리 삭제

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
@@ -77,7 +77,7 @@ public class ArticleController implements ArticleApi {
 
     @Override
     @DeleteMapping("/{articleId}/hard")
-    public ResponseEntity<Void> deleteHard(UUID articleId) {
+    public ResponseEntity<Void> deleteHard(@PathVariable UUID articleId) {
         log.info("기사 물리 삭제 요청 - articleId: {}", articleId);
         articleService.deleteHard(articleId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
@@ -1,9 +1,15 @@
 package com.sprint.mission.sb03monewteam1.controller;
 
+import com.sprint.mission.sb03monewteam1.controller.api.ArticleApi;
+import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
+import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
+import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
+import com.sprint.mission.sb03monewteam1.service.ArticleService;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,15 +19,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.sprint.mission.sb03monewteam1.controller.api.ArticleApi;
-import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
-import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
-import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
-import com.sprint.mission.sb03monewteam1.service.ArticleService;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
@@ -75,6 +72,14 @@ public class ArticleController implements ArticleApi {
     public ResponseEntity<Void> delete(@PathVariable UUID articleId) {
         log.info("기사 삭제 요청 - articleId: {}", articleId);
         articleService.delete(articleId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @DeleteMapping("/{articleId}/hard")
+    public ResponseEntity<Void> deleteHard(UUID articleId) {
+        log.info("기사 물리 삭제 요청 - articleId: {}", articleId);
+        articleService.deleteHard(articleId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/ArticleApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/ArticleApi.java
@@ -1,32 +1,25 @@
 package com.sprint.mission.sb03monewteam1.controller.api;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.UUID;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
 import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.exception.ErrorResponse;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "기사 관리", description = "기사 조회 및 뷰 관리 API")
-@RequestMapping("/api/articles")
 public interface ArticleApi {
 
     @Operation(summary = "기사 뷰 등록", description = "사용자가 기사를 조회했음을 기록합니다.")
@@ -35,7 +28,6 @@ public interface ArticleApi {
         @ApiResponse(responseCode = "404", description = "기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @PostMapping("/{articleId}/article-views")
     ResponseEntity<ArticleViewDto> createArticleView(
         @RequestHeader("Monew-Request-User-ID") UUID userId,
         @PathVariable UUID articleId);
@@ -64,15 +56,21 @@ public interface ArticleApi {
         @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = String.class))),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @GetMapping("/sources")
     ResponseEntity<List<String>> getSources();
 
     @Operation(summary = "기사 논리 삭제")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "논리 삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> delete(@PathVariable UUID articleId);
+
+    @Operation(summary = "기사 물리 삭제")
     @ApiResponses({
         @ApiResponse(responseCode = "204", description = "삭제 성공"),
         @ApiResponse(responseCode = "404", description = "기사 정보 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @DeleteMapping("/{articleId}")
-    ResponseEntity<Void> delete(@PathVariable UUID articleId);
+    ResponseEntity<Void> deleteHard(@PathVariable UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Article.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Article.java
@@ -5,15 +5,11 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +23,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
 
     @Column(name = "source", nullable = false, length = 50)
     private String source;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/ArticleView.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/ArticleView.java
@@ -1,19 +1,14 @@
 package com.sprint.mission.sb03monewteam1.entity;
 
-import java.util.UUID;
-
 import com.sprint.mission.sb03monewteam1.entity.base.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,15 +17,12 @@ import lombok.NoArgsConstructor;
 
 @Builder
 @Entity
-@Table(name = "article_views", uniqueConstraints = @UniqueConstraint(columnNames = { "user_id", "article_id" }))
+@Table(name = "article_views", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id",
+    "article_id"}))
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleView extends BaseEntity {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
@@ -41,8 +33,8 @@ public class ArticleView extends BaseEntity {
 
     public static ArticleView createArticleView(UUID userId, Article article) {
         return ArticleView.builder()
-                .userId(userId)
-                .article(article)
-                .build();
+            .userId(userId)
+            .article(article)
+            .build();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/User.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/User.java
@@ -9,7 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Where;
 
 @Builder
 @Entity

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/base/BaseEntity.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/base/BaseEntity.java
@@ -26,4 +26,7 @@ public abstract class BaseEntity {
     @Column(columnDefinition = "timestamp with time zone", updatable = false, nullable = false)
     private Instant createdAt;
 
+    public void setIdForTest(UUID id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleInterestRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleInterestRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ArticleInterestRepository extends JpaRepository<ArticleInterest, UUID> {
 
+    void deleteByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleInterestRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleInterestRepository.java
@@ -4,9 +4,11 @@ import com.sprint.mission.sb03monewteam1.entity.ArticleInterest;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ArticleInterestRepository extends JpaRepository<ArticleInterest, UUID> {
 
+    @Transactional
     void deleteByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleViewRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleViewRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
@@ -13,5 +14,6 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
 
     List<ArticleView> findByUserIdAndArticleId(UUID userId, UUID articleId);
 
+    @Transactional
     void deleteByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleViewRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/ArticleViewRepository.java
@@ -1,12 +1,10 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
+import com.sprint.mission.sb03monewteam1.entity.ArticleView;
 import java.util.List;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import com.sprint.mission.sb03monewteam1.entity.ArticleView;
 
 @Repository
 public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> {
@@ -14,4 +12,6 @@ public interface ArticleViewRepository extends JpaRepository<ArticleView, UUID> 
     boolean existsByUserIdAndArticleId(UUID userId, UUID articleId);
 
     List<ArticleView> findByUserIdAndArticleId(UUID userId, UUID articleId);
+
+    void deleteByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.repository;
 
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -26,4 +27,6 @@ public interface CommentRepository extends JpaRepository<Comment, UUID>, Comment
     void decreaseLikeCountAndDeleteById(@Param("commentId") UUID commentId);
 
     Optional<Comment> findByIdAndIsDeletedFalse(UUID commentId);
+
+    List<Comment> findAllByArticleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleService.java
@@ -31,4 +31,6 @@ public interface ArticleService {
     void collectAndSaveHankyungArticles(Interest interest, String keyword);
 
     void delete(UUID articleId);
+
+    void deleteHard(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -237,6 +237,15 @@ public class ArticleServiceImpl implements ArticleService {
         article.markAsDeleted();
     }
 
+    @Override
+    @Transactional
+    public void deleteHard(UUID articleId) {
+        Article article = articleRepository.findById(articleId)
+            .orElseThrow(() -> new ArticleNotFoundException(articleId.toString()));
+
+        // TODO: 물리 삭제 구현
+    }
+
     private Article getActiveArticle(UUID articleId) {
         return articleRepository.findByIdAndIsDeletedFalse(articleId)
             .orElseThrow(() -> new ArticleNotFoundException(articleId.toString()));

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -9,6 +9,7 @@ import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.ArticleInterest;
 import com.sprint.mission.sb03monewteam1.entity.ArticleView;
+import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
@@ -18,6 +19,8 @@ import com.sprint.mission.sb03monewteam1.mapper.ArticleViewMapper;
 import com.sprint.mission.sb03monewteam1.repository.ArticleInterestRepository;
 import com.sprint.mission.sb03monewteam1.repository.ArticleRepository;
 import com.sprint.mission.sb03monewteam1.repository.ArticleViewRepository;
+import com.sprint.mission.sb03monewteam1.repository.CommentLikeRepository;
+import com.sprint.mission.sb03monewteam1.repository.CommentRepository;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -40,11 +43,15 @@ public class ArticleServiceImpl implements ArticleService {
 
     private final ArticleRepository articleRepository;
     private final ArticleViewRepository articleViewRepository;
+    private final ArticleInterestRepository articleInterestRepository;
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+
     private final ArticleMapper articleMapper;
     private final ArticleViewMapper articleViewMapper;
+
     private final NaverNewsCollector naverNewsCollector;
     private final HankyungNewsCollector hankyungNewsCollector;
-    private final ArticleInterestRepository articleInterestRepository;
 
     @Override
     @Transactional
@@ -240,10 +247,21 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     @Transactional
     public void deleteHard(UUID articleId) {
-        Article article = articleRepository.findById(articleId)
+        articleRepository.findById(articleId)
             .orElseThrow(() -> new ArticleNotFoundException(articleId.toString()));
 
-        // TODO: 물리 삭제 구현
+        List<Comment> comments = commentRepository.findAllByArticleId(articleId);
+
+        for (Comment comment : comments) {
+            UUID commentId = comment.getId();
+            commentLikeRepository.deleteByCommentId(commentId);
+            commentRepository.deleteById(commentId);
+        }
+
+        articleViewRepository.deleteByArticleId(articleId);
+        articleInterestRepository.deleteByArticleId(articleId);
+
+        articleRepository.deleteById(articleId);
     }
 
     private Article getActiveArticle(UUID articleId) {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/ArticleControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/ArticleControllerTest.java
@@ -252,4 +252,27 @@ class ArticleControllerTest {
             .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.name()))
             .andExpect(jsonPath("$.message").exists());
     }
+
+    @Test
+    void 기사_물리_삭제_성공() throws Exception {
+        UUID articleId = UUID.randomUUID();
+        willDoNothing().given(articleService).deleteHard(articleId);
+
+        mockMvc.perform(delete("/api/articles/" + articleId + "/hard"))
+            .andExpect(status().isNoContent());
+
+        then(articleService).should().deleteHard(articleId);
+    }
+
+    @Test
+    void 기사_물리_삭제_실패_기사없음() throws Exception {
+        UUID articleId = UUID.randomUUID();
+        willThrow(new ArticleNotFoundException(articleId.toString()))
+            .given(articleService).deleteHard(articleId);
+
+        mockMvc.perform(delete("/api/articles/" + articleId + "/hard"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.name()))
+            .andExpect(jsonPath("$.message").exists());
+    }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/ArticleFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/ArticleFixture.java
@@ -16,7 +16,6 @@ public class ArticleFixture {
     public static final Boolean DEFAULT_IS_DELETED = false;
     public static final Instant DEFAULT_PUBLISH_DATE = Instant.parse("2024-01-01T10:00:00Z");
 
-    // 기본 Article 생성
     public static Article createArticle() {
         return Article.builder()
             .source(DEFAULT_SOURCE)
@@ -30,7 +29,6 @@ public class ArticleFixture {
             .build();
     }
 
-    // 커스텀 Article 생성
     public static Article createArticle(String source, String sourceUrl, String title) {
         return Article.builder()
             .source(source)
@@ -44,22 +42,6 @@ public class ArticleFixture {
             .build();
     }
 
-    // ID가 있는 Article 생성
-    public static Article createArticleWithId(UUID id) {
-        return Article.builder()
-            .id(id)
-            .source(DEFAULT_SOURCE)
-            .sourceUrl(DEFAULT_SOURCE_URL + "/" + id)
-            .title(DEFAULT_TITLE)
-            .publishDate(DEFAULT_PUBLISH_DATE)
-            .summary(DEFAULT_SUMMARY)
-            .viewCount(DEFAULT_VIEW_COUNT)
-            .commentCount(DEFAULT_COMMENT_COUNT)
-            .isDeleted(DEFAULT_IS_DELETED)
-            .build();
-    }
-
-    // 조회수가 있는 Article 생성
     public static Article createArticleWithViewCount(Long viewCount) {
         return Article.builder()
             .source(DEFAULT_SOURCE)
@@ -73,7 +55,6 @@ public class ArticleFixture {
             .build();
     }
 
-    // 댓글수가 있는 Article 생성
     public static Article createArticleWithCommentCount(Long commentCount) {
         return Article.builder()
             .source(DEFAULT_SOURCE)
@@ -87,7 +68,6 @@ public class ArticleFixture {
             .build();
     }
 
-    // 삭제된 Article 생성
     public static Article createDeletedArticle() {
         return Article.builder()
             .source(DEFAULT_SOURCE)
@@ -99,5 +79,20 @@ public class ArticleFixture {
             .commentCount(DEFAULT_COMMENT_COUNT)
             .isDeleted(true)
             .build();
+    }
+
+    public static Article createArticleWithId(UUID id) {
+        Article article = Article.builder()
+            .source(DEFAULT_SOURCE)
+            .sourceUrl(DEFAULT_SOURCE_URL)
+            .title(DEFAULT_TITLE)
+            .publishDate(DEFAULT_PUBLISH_DATE)
+            .summary(DEFAULT_SUMMARY)
+            .viewCount(DEFAULT_VIEW_COUNT)
+            .commentCount(DEFAULT_COMMENT_COUNT)
+            .isDeleted(DEFAULT_IS_DELETED)
+            .build();
+        article.setIdForTest(id); // 테스트 전용 id 세팅
+        return article;
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/ArticleViewFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/ArticleViewFixture.java
@@ -6,10 +6,8 @@ import java.util.UUID;
 
 public class ArticleViewFixture {
 
-    // 기본값 상수
     public static final UUID DEFAULT_USER_ID = UUID.randomUUID();
 
-    // 기본 ArticleView 생성
     public static ArticleView createArticleView() {
         return ArticleView.builder()
             .userId(DEFAULT_USER_ID)
@@ -17,18 +15,8 @@ public class ArticleViewFixture {
             .build();
     }
 
-    // 사용자 ID와 Article을 지정한 ArticleView 생성
     public static ArticleView createArticleView(UUID userId, Article article) {
         return ArticleView.builder()
-            .userId(userId)
-            .article(article)
-            .build();
-    }
-
-    // ID가 있는 ArticleView 생성
-    public static ArticleView createArticleViewWithId(UUID id, UUID userId, Article article) {
-        return ArticleView.builder()
-            .id(id)
             .userId(userId)
             .article(article)
             .build();

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/CommentFixture.java
@@ -93,4 +93,15 @@ public class CommentFixture {
             .likedByMe(false)
             .build();
     }
+
+    public static Comment createCommentWithId(UUID id, User user, Article article) {
+        Comment comment = Comment.builder()
+            .content(DEFAULT_COMMENT)
+            .author(user)
+            .article(article)
+            .likeCount(DEFAULT_LIKE_COUNT)
+            .build();
+        comment.setIdForTest(id);
+        return comment;
+    }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 삭제
  - 관련된 정보가 유지되도록 논리 삭제를 기본 원칙으로 하세요.
  - 단, 물리 삭제 시 관련된 정보도 모두 삭제되도록 하세요.

### ✅ 완료한 작업
- [x] 뉴스 기사 물리 삭제

### 🧪 테스트 결과
- 기사 물리 삭제 시 연관 데이터 모두 삭제
- 존재하지 않는 기사 물리 삭제 요청 시 예외

### ⚠️ 기타 참고 사항
- 연계 작업이라서 논리 삭제 브랜치를 기준으로 이어서 작업했습니다.
- 충돌 발생 시 빠르게 해결하겠습니다.

### Related Issue

Closes #73 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 기사 논리 삭제(soft delete) 및 물리 삭제(hard delete) API가 추가되었습니다.
  * 기사 소스 목록을 조회하는 API가 추가되었습니다.

* **버그 수정**
  * 일부 엔터티의 불필요한 ID 필드가 제거되었습니다.

* **문서화**
  * 기사 관련 API에 대한 응답 코드 및 스키마가 Swagger 문서에 추가되었습니다.

* **테스트**
  * 기사 삭제 기능(논리/물리)에 대한 단위 테스트와 컨트롤러 테스트가 추가되었습니다.
  * 테스트용 Fixture 메서드가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->