### PR TITLE
[feat][MN-16] 댓글 좋아요 취소 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -136,4 +136,19 @@ public class CommentController implements CommentApi {
             .status(HttpStatus.OK)
             .body(result);
     }
+
+    @Override
+    @DeleteMapping(path = "/{commentId}/comment-likes")
+    public ResponseEntity<Void> likeCancel(
+        @PathVariable UUID commentId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId) {
+
+        log.info("댓글 좋아요 취소 요청: commentId = {}, userId = {}", commentId, userId);
+
+        commentService.likeCancel(commentId, userId);
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/CommentApi.java
@@ -233,4 +233,31 @@ public interface CommentApi {
         @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
         @Parameter(description = "요청자 ID", required = true) @RequestHeader("Monew-Request-User-ID") UUID userId
     );
+
+    @Operation(summary = "댓글 좋아요 취소")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204", description = "댓글 좋아요 취소 성공"
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "댓글 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> likeCancel(
+        @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Monew-Request-User-ID") UUID userId
+    );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     // 댓글 관련 예외
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 누른 댓글입니다."),
+    COMMENT_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요 정보를 찾을 수 없습니다."),
 
     // 커서 기반 페이지네이션 관련 예외
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 커서 형식입니다."),

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentLikeNotFoundException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/comment/CommentLikeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.sprint.mission.sb03monewteam1.exception.comment;
+
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class CommentLikeNotFoundException extends CommentException {
+
+  public CommentLikeNotFoundException(UUID userId, UUID commentId) {
+    super(ErrorCode.COMMENT_LIKE_NOT_FOUND,
+        Map.of("userId", String.valueOf(userId), "commentId", String.valueOf(commentId)));
+  }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentLikeRepository.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.repository;
 
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -31,4 +32,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, UUID> 
         @Param("userId") UUID userId,
         @Param("commentIds") List<UUID> commentIds
     );
+
+    Optional<CommentLike> findByUserIdAndCommentId(UUID userId, UUID commentId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -31,4 +31,6 @@ public interface CommentService {
     void deleteHard(UUID commentId);
 
     CommentLikeDto like(UUID commentId, UUID userId);
+
+    void likeCancel(UUID commentId, UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -12,6 +12,7 @@ import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentAlreadyLikedException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentException;
+import com.sprint.mission.sb03monewteam1.exception.comment.CommentLikeNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.comment.UnauthorizedCommentAccessException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
@@ -264,6 +265,11 @@ public class CommentServiceImpl implements CommentService {
         log.info("댓글 좋아요 등록 완료 : 댓글 좋아요 ID = {}", commentLike.getId());
 
         return commentLikeMapper.toDto(commentLike);
+    }
+
+    @Override
+    public void likeCancel(UUID commentId, UUID userId) {
+
     }
 
     private void validateAuthor(Comment comment, UUID userId) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -270,6 +270,21 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public void likeCancel(UUID commentId, UUID userId) {
 
+        log.info("댓글 좋아요 취소 시작 : 댓글 ID = {}, 유저 ID = {}", commentId, userId);
+
+        // 댓글 유효성
+        Comment comment = commentRepository.findByIdAndIsDeletedFalse(commentId)
+            .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        // 댓글 좋아요 여부 확인
+        CommentLike commentLike = commentLikeRepository.findByUserIdAndCommentId(userId, commentId)
+            .orElseThrow(() -> new CommentLikeNotFoundException(userId, commentId));
+
+        // 댓글 좋아요 -1
+        commentLikeRepository.deleteById(commentLike.getId());
+        comment.decreaseLikeCount();
+
+        log.info("댓글 좋아요 취소 완료 : 댓글 ID = {}, 유저 ID = {}", commentId, userId);
     }
 
     private void validateAuthor(Comment comment, UUID userId) {

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -938,7 +938,7 @@ public class CommentServiceTest {
             ReflectionTestUtils.setField(savedCommentLike, "id", commentLikeId);
 
             given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
-            given(commentLikeRepository.findByUserIdAndCommentId(commentId, userId)).willReturn(Optional.of(savedCommentLike));
+            given(commentLikeRepository.findByUserIdAndCommentId(userId, commentId)).willReturn(Optional.of(savedCommentLike));
             willDoNothing().given(commentLikeRepository).deleteById(commentLikeId);
 
             // when
@@ -947,7 +947,7 @@ public class CommentServiceTest {
             // then
             assertThat(comment.getLikeCount()).isEqualTo(0L);
             then(commentRepository).should().findByIdAndIsDeletedFalse(commentId);
-            then(commentLikeRepository).should().findByUserIdAndCommentId(commentId, userId);
+            then(commentLikeRepository).should().findByUserIdAndCommentId(userId, commentId);
             then(commentLikeRepository).should().deleteById(commentLikeId);
         }
 
@@ -981,7 +981,7 @@ public class CommentServiceTest {
             Comment comment = CommentFixture.createCommentWithLikeCount("좋아요 취소 테스트", user, article, 1L);
 
             given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
-            given(commentLikeRepository.findByUserIdAndCommentId(commentId, userId)).willReturn(Optional.empty());
+            given(commentLikeRepository.findByUserIdAndCommentId(userId, commentId)).willReturn(Optional.empty());
 
             // when & then
             Assertions.assertThatThrownBy(() -> {
@@ -989,8 +989,20 @@ public class CommentServiceTest {
             }).isInstanceOf(CommentLikeNotFoundException.class);
 
             then(commentRepository).should().findByIdAndIsDeletedFalse(commentId);
-            then(commentLikeRepository).should().findByUserIdAndCommentId(commentId, userId);
+            then(commentLikeRepository).should().findByUserIdAndCommentId(userId, commentId);
         }
+    }
+
+    private List<Comment> createCommentsWithCreatedAt(int count, Article article, User user) {
+        List<Comment> comments = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            Instant createdAt = Instant.now().plusMillis(i);
+            Comment comment = CommentFixture.createCommentWithCreatedAt("test" + i, user, article, createdAt);
+            ReflectionTestUtils.setField(comment, "createdAt", createdAt);
+            ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+            comments.add(comment);
+        }
+        return comments;
     }
 
     private List<Comment> createCommentsWithLikeCount(int count, Article article, User user) {


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 좋아요 취소 API 구현

### ✅ 완료한 작업
- [x] 댓글 좋아요 취소 로직 구현
- [x] 컨트롤러/서비스 테스트 코드 작성

### 🧪 테스트 결과
- 테스트 코드 통과
- 로컬 환경 테스트 완료

### ⚠️ 기타 참고 사항
- 아직 남은 작업이나, 리뷰어가 확인해야 할 이슈

### Related Issue

Closes #79 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글에 대한 좋아요 취소(Unlike) 기능이 추가되었습니다. 이제 사용자는 댓글의 좋아요를 취소할 수 있습니다.

* **버그 수정**
  * 좋아요 취소 시, 존재하지 않는 댓글 또는 좋아요 정보가 없는 경우 각각 적절한 오류 메시지와 상태 코드(404)를 반환합니다.

* **테스트**
  * 댓글 좋아요 취소 기능에 대한 단위 테스트 및 컨트롤러 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->