### PR TITLE
[feat] [MN-61] 논리 삭제된 댓글을 제외한 총 댓글 수 집계 로직 수정

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/CommentRepository.java
@@ -13,7 +13,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
 
-    Long countByArticleId(UUID articleId);
+    long countByIsDeletedFalse();
+
+    long countByArticleIdAndIsDeletedFalse(UUID articleId);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Comment c " +

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -141,8 +141,8 @@ public class CommentServiceImpl implements CommentService {
         }
 
         Long totalElements = (articleId == null)
-            ? commentRepository.count()
-            : commentRepository.countByArticleId(articleId);
+            ? commentRepository.countByIsDeletedFalse()
+            : commentRepository.countByArticleIdAndIsDeletedFalse(articleId);
 
         comments = hasNext ? comments.subList(0, size) : comments;
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -198,7 +198,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(firstPage);
-            given(commentRepository.countByArticleId(articleId)).willReturn(10L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId)).willReturn(10L);
             given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
                 Comment comment = invocation.getArgument(0);
                 return CommentFixture.createCommentDto(comment);
@@ -255,7 +255,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(firstPage);
-            given(commentRepository.countByArticleId(articleId)).willReturn(10L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId)).willReturn(10L);
             given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
                     Comment comment = invocation.getArgument(0);
                     return CommentFixture.createCommentDto(comment);
@@ -307,7 +307,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(cursor.toString()), eq(after), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(secondPage);
-            given(commentRepository.countByArticleId(article.getId())).willReturn(10L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(article.getId())).willReturn(10L);
             given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
                     Comment comment = invocation.getArgument(0);
                     return CommentFixture.createCommentDto(comment);
@@ -364,7 +364,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(nextCursor.toString()), eq(nextAfter), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(lastPage);
-            given(commentRepository.countByArticleId(articleId)).willReturn(10L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId)).willReturn(10L);
             given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
                     Comment comment = invocation.getArgument(0);
                     return CommentFixture.createCommentDto(comment);
@@ -410,7 +410,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(Collections.emptyList());
-            given(commentRepository.countByArticleId(article.getId())).willReturn(0L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(article.getId())).willReturn(0L);
 
             // when
             CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
@@ -446,7 +446,7 @@ public class CommentServiceTest {
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(commentList.subList(0, pageSize));
-            given(commentRepository.countByArticleId(articleId)).willReturn(5L);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(articleId)).willReturn(5L);
             given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
                 Comment comment = invocation.getArgument(0);
                 return CommentFixture.createCommentDto(comment);


### PR DESCRIPTION
### 📌 작업 개요
- 논리 삭제된 댓글을 제외한 총 댓글 수 집계 로직 수정

### ✅ 완료한 작업
- [x] isDeleted = false인 댓글만 카운트하도록 로직 수정

### 🧪 테스트 결과
- 테스트 코드 통과
- 로컬 환경 테스트 완료


### ⚠️ 기타 참고 사항
- 없음

### Related Issue

Closes #71 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 삭제되지 않은 댓글만 집계하도록 댓글 수 집계 로직이 개선되었습니다.

* **테스트**
  * 테스트 코드에서 삭제된 댓글을 제외하고 댓글 수를 집계하도록 검증 로직이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->