### PR TITLE
[feat] [MN-32] 전체 알림 확인 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/NotificationController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/NotificationController.java
@@ -62,4 +62,20 @@ public class NotificationController implements NotificationApi {
             .status(HttpStatus.OK)
             .body(result);
     }
+
+    @Override
+    @PatchMapping
+    public ResponseEntity<Void> confirmAll(
+        @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        log.info("알림 전체 확인 요청: userId={}", userId);
+
+        notificationService.confirmAll(userId);
+
+        log.info("알림 전체 확인 완료: userId={}", userId);
+
+        return ResponseEntity
+            .status(HttpStatus.NO_CONTENT)
+            .build();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/NotificationApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/NotificationApi.java
@@ -1,22 +1,22 @@
 package com.sprint.mission.sb03monewteam1.controller.api;
 
 import com.sprint.mission.sb03monewteam1.dto.NotificationDto;
+import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import java.time.Instant;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "알림 관리", description = "알림 관련 API")
@@ -54,6 +54,41 @@ public interface NotificationApi {
         @RequestParam(required = false) Instant after,
         @RequestParam(defaultValue = "50") @Min(1) @Max(100) int limit,
         @RequestHeader("Monew-Request-User-ID") UUID userId
+    );
+
+    @Operation(summary = "전체 알림 확인")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "전체 알림 확인 성공"
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (입력값 검증 실패)",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자 정보 없음",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "*/*",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> confirmAll(
+        @Parameter(description = "요청자 ID", required = true) @RequestHeader("Monew-Request-User-ID") UUID userId
     );
 
     @Operation(summary = "알림 확인")

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
@@ -1,10 +1,13 @@
 package com.sprint.mission.sb03monewteam1.repository.jpa.notification;
 
 import com.sprint.mission.sb03monewteam1.entity.Notification;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
 
     long countByUserIdAndIsCheckedFalse(UUID userId);
+
+    List<Notification> findByUserIdAndIsCheckedFalse(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/user/UserRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/user/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByEmail(String email);
 
+    boolean existsByIdAndIsDeletedFalse(UUID id);
+
     Optional<User> findByIdAndIsDeletedFalse(UUID id);
 
     Optional<User> findByEmail(String email);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
@@ -6,6 +6,7 @@ import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 public interface NotificationService {
@@ -15,6 +16,8 @@ public interface NotificationService {
     void createCommentLikeNotification(User user, Comment comment);
 
     NotificationDto confirm(UUID notificationId, UUID userId);
+
+    List<NotificationDto> confirmAll(UUID userId);
 
     CursorPageResponse<NotificationDto> getUncheckedNotifications(
         UUID userId,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
@@ -17,7 +17,7 @@ public interface NotificationService {
 
     NotificationDto confirm(UUID notificationId, UUID userId);
 
-    List<NotificationDto> confirmAll(UUID userId);
+    void confirmAll(UUID userId);
 
     CursorPageResponse<NotificationDto> getUncheckedNotifications(
         UUID userId,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -132,7 +132,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     @Override
-    public List<NotificationDto> confirmAll(UUID userId) {
+    public void confirmAll(UUID userId) {
 
         log.info("알림 전체 확인 시작: userId={}", userId);
 
@@ -141,9 +141,5 @@ public class NotificationServiceImpl implements NotificationService {
         notifications.forEach(Notification::markAsChecked);
 
         log.info("알림 전체 확인 완료: userId={}", userId);
-
-        return notifications.stream()
-            .map(notificationMapper::toDto)
-            .toList();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -130,4 +130,9 @@ public class NotificationServiceImpl implements NotificationService {
 
         return notificationMapper.toDto(notification);
     }
+
+    @Override
+    public List<NotificationDto> confirmAll(UUID userId) {
+        return List.of();
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -9,8 +9,10 @@ import com.sprint.mission.sb03monewteam1.entity.Notification;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.notification.NotificationAccessDeniedException;
 import com.sprint.mission.sb03monewteam1.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.sb03monewteam1.exception.user.UserNotFoundException;
 import com.sprint.mission.sb03monewteam1.mapper.NotificationMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.notification.NotificationRepository;
+import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
     private final NotificationMapper notificationMapper;
 
     @Override
@@ -136,10 +139,14 @@ public class NotificationServiceImpl implements NotificationService {
 
         log.info("알림 전체 확인 시작: userId={}", userId);
 
+        if (!userRepository.existsByIdAndIsDeletedFalse(userId)) {
+            throw new UserNotFoundException(userId);
+        }
+
         List<Notification> notifications = notificationRepository.findByUserIdAndIsCheckedFalse(userId);
 
         notifications.forEach(Notification::markAsChecked);
 
-        log.info("알림 전체 확인 완료: userId={}", userId);
+        log.info("알림 전체 확인 완료: userId={}, 확인된 알림 수={}", userId, notifications.size());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -133,6 +133,17 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public List<NotificationDto> confirmAll(UUID userId) {
-        return List.of();
+
+        log.info("알림 전체 확인 시작: userId={}", userId);
+
+        List<Notification> notifications = notificationRepository.findByUserIdAndIsCheckedFalse(userId);
+
+        notifications.forEach(Notification::markAsChecked);
+
+        log.info("알림 전체 확인 완료: userId={}", userId);
+
+        return notifications.stream()
+            .map(notificationMapper::toDto)
+            .toList();
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
@@ -302,7 +302,7 @@ public class NotificationControllerTest {
             willDoNothing().given(notificationService).confirmAll(userId);
 
             // when & Then
-            mockMvc.perform(patch("/api/notifications/")
+            mockMvc.perform(patch("/api/notifications")
                     .header("Monew-Request-User-ID", userId.toString()))
                 .andExpect(status().isNoContent());
         }
@@ -318,7 +318,7 @@ public class NotificationControllerTest {
                 .confirmAll(invalidUserId);
 
             // when & then
-            mockMvc.perform(patch("/api/notifications/")
+            mockMvc.perform(patch("/api/notifications")
                     .header("Monew-Request-User-ID", invalidUserId.toString()))
                 .andExpect(status().isNotFound());
         }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static java.util.UUID.randomUUID;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -18,6 +19,7 @@ import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.notification.NotificationAccessDeniedException;
 import com.sprint.mission.sb03monewteam1.exception.notification.NotificationNotFoundException;
+import com.sprint.mission.sb03monewteam1.exception.user.UserNotFoundException;
 import com.sprint.mission.sb03monewteam1.fixture.NotificationFixture;
 import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.service.NotificationService;
@@ -303,6 +305,22 @@ public class NotificationControllerTest {
             mockMvc.perform(patch("/api/notifications/")
                     .header("Monew-Request-User-ID", userId.toString()))
                 .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void 존재하지_않는_유저가_알림을_전체_확인하면_404가_반환되어야_한다() throws Exception {
+
+            // given
+            UUID invalidUserId = UUID.randomUUID();
+
+            willThrow(new UserNotFoundException(invalidUserId))
+                .given(notificationService)
+                .confirmAll(invalidUserId);
+
+            // when & then
+            mockMvc.perform(patch("/api/notifications/")
+                    .header("Monew-Request-User-ID", invalidUserId.toString()))
+                .andExpect(status().isNotFound());
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/NotificationControllerTest.java
@@ -3,6 +3,7 @@ package com.sprint.mission.sb03monewteam1.controller;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static java.util.UUID.randomUUID;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -22,6 +23,7 @@ import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.service.NotificationService;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -287,6 +289,20 @@ public class NotificationControllerTest {
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(ErrorCode.FORBIDDEN_ACCESS.name()))
                 .andExpect(jsonPath("$.message").exists());
+        }
+
+        @Test
+        void 알림을_전체_확인하면_204가_반환되어야_한다() throws Exception {
+
+            // given
+            UUID userId = UUID.randomUUID();
+
+            willDoNothing().given(notificationService).confirmAll(userId);
+
+            // when & Then
+            mockMvc.perform(patch("/api/notifications/")
+                    .header("Monew-Request-User-ID", userId.toString()))
+                .andExpect(status().isNoContent());
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -375,18 +376,10 @@ public class NotificationServiceTest {
 
             given(notificationRepository.findByUserIdAndIsCheckedFalse(userId)).willReturn(notifications);
 
-            given(notificationMapper.toDto(any(Notification.class)))
-                .willAnswer(invocation -> {
-                    Notification n = invocation.getArgument(0);
-                    return NotificationFixture.createNotificationDtoWithConfirmed(n, true);
-                });
-
             // when
-            List<NotificationDto> result = notificationService.confirmAll(userId);
+            notificationService.confirmAll(userId);
 
             // then
-            assertThat(result).hasSize(5);
-            assertThat(result).allMatch(NotificationDto::confirmed);
             assertThat(notifications).allMatch(Notification::isChecked);
         }
 
@@ -398,10 +391,8 @@ public class NotificationServiceTest {
             given(notificationRepository.findByUserIdAndIsCheckedFalse(userId)).willReturn(List.of());
 
             // when
-            List<NotificationDto> result = notificationService.confirmAll(userId);
-
-            // then
-            assertThat(result).isEmpty();
+            assertThatCode(() -> notificationService.confirmAll(userId))
+                .doesNotThrowAnyException();
         }
     }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 전체 알림 확인 기능 구현

### ✅ 완료한 작업
- [x] 전체 알림 확인 로직 구현
- [x] 서비스/컨트롤러/통합 테스트 코드 작성

### 🧪 테스트 결과
- 모든 테스트 코드 통과
- 로컬 환경 테스트 완료

### ⚠️ 기타 참고 사항
- 응답 코드: 204 No Content
- 반환값은 void로 설정 (개별/전체 알림 확인 공통 적용)

### Related Issue

Closes #89 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 개별 알림 또는 전체 알림을 확인(읽음 처리)할 수 있는 PATCH API가 추가되었습니다.

* **Bug Fixes**
  * 없음

* **Tests**
  * 알림 확인 및 전체 확인 API에 대한 단위 테스트 및 통합 테스트가 추가되어 다양한 예외 상황과 정상 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->