### PR TITLE
[feat] [MN-22] 관심사 삭제 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
@@ -57,7 +57,6 @@ public class InterestController implements InterestApi {
     }
 
     @PostMapping("/{interestId}/subscriptions")
-
     public ResponseEntity<SubscriptionDto> createSubscription(
         @PathVariable UUID interestId,
         @RequestHeader("Monew-Request-User-ID") UUID userId) {
@@ -70,5 +69,17 @@ public class InterestController implements InterestApi {
             userId, interestId, subscriptionDto.interestName());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(subscriptionDto);
+    }
+
+    @DeleteMapping("/{interestId}")
+    public ResponseEntity<Void> deleteInterest(@PathVariable UUID interestId) {
+
+        log.info("관심사 삭제 요청: interestId={}", interestId);
+
+        interestService.deleteInterest(interestId);
+
+        log.info("관심사 삭제 완료: interestId={}", interestId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Interest.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Interest.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.entity;
 
 import com.sprint.mission.sb03monewteam1.entity.base.BaseUpdatableEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,9 @@ import java.util.List;
 @Table(name = "interests")
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Interest extends BaseUpdatableEntity {
 
     @Column(nullable = false)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/InterestKeyword.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/InterestKeyword.java
@@ -2,19 +2,18 @@ package com.sprint.mission.sb03monewteam1.entity;
 
 import com.sprint.mission.sb03monewteam1.entity.base.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Table(name = "interest_keywords")
 @Getter
-@Setter
-@NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InterestKeyword extends BaseEntity {
 
     @Column(nullable = false)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/interest/InterestKeywordRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/interest/InterestKeywordRepository.java
@@ -14,4 +14,6 @@ public interface InterestKeywordRepository extends JpaRepository<InterestKeyword
     List<String> findAllDistinct();
 
     List<InterestKeyword> findAllByKeyword(String keyword);
+
+    void deleteByInterestId(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/interest/InterestKeywordRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/interest/InterestKeywordRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface InterestKeywordRepository extends JpaRepository<InterestKeyword, UUID> {
 
@@ -15,5 +16,6 @@ public interface InterestKeywordRepository extends JpaRepository<InterestKeyword
 
     List<InterestKeyword> findAllByKeyword(String keyword);
 
+    @Transactional
     void deleteByInterestId(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
@@ -24,5 +24,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.user WHERE s.interest.id = :interestId")
     List<Subscription> findAllByInterestIdFetchUser(@Param("interestId") UUID interestId);
 
+    @Transactional
     void deleteByInterestId(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
@@ -23,4 +23,6 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
 
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.user WHERE s.interest.id = :interestId")
     List<Subscription> findAllByInterestIdFetchUser(@Param("interestId") UUID interestId);
+
+    void deleteByInterestId(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
@@ -19,4 +19,6 @@ public interface InterestService {
         String sortDirection);
 
     SubscriptionDto createSubscription(UUID interestId, UUID userId);
+
+    void deleteInterest(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -17,6 +17,7 @@ import com.sprint.mission.sb03monewteam1.exception.interest.InterestSimilarityEx
 import com.sprint.mission.sb03monewteam1.exception.user.UserNotFoundException;
 import com.sprint.mission.sb03monewteam1.mapper.InterestMapper;
 import com.sprint.mission.sb03monewteam1.mapper.SubscriptionMapper;
+import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestKeywordRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.subscription.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
@@ -41,6 +42,7 @@ public class InterestServiceImpl implements InterestService {
 
     private final InterestRepository interestRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final InterestKeywordRepository interestKeywordRepository;
     private final UserRepository userRepository;
     private final InterestMapper interestMapper;
     private final SubscriptionMapper subscriptionMapper;
@@ -175,12 +177,17 @@ public class InterestServiceImpl implements InterestService {
 
     @Override
     public void deleteInterest(UUID interestId) {
+        log.info("관심사 삭제 요청: interestId={}", interestId);
         Interest interest = interestRepository.findById(interestId)
             .orElseThrow(() -> new InterestNotFoundException(interestId));
 
         subscriptionRepository.deleteByInterestId(interestId);
 
+        interestKeywordRepository.deleteByInterestId(interestId);
+
         interestRepository.delete(interest);
+
+        log.info("관심사 삭제 완료: interestId={}", interestId);
     }
 
     private String calculateNextCursor(List<Interest> interests, String orderBy, int limit) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -173,6 +173,16 @@ public class InterestServiceImpl implements InterestService {
         return subscriptionMapper.toDto(savedSubscription);
     }
 
+    @Override
+    public void deleteInterest(UUID interestId) {
+        Interest interest = interestRepository.findById(interestId)
+            .orElseThrow(() -> new InterestNotFoundException(interestId));
+
+        subscriptionRepository.deleteByInterestId(interestId);
+
+        interestRepository.delete(interest);
+    }
+
     private String calculateNextCursor(List<Interest> interests, String orderBy, int limit) {
         if (interests.size() <= limit) {
             return null;

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
@@ -435,14 +435,13 @@ class InterestControllerTest {
             mockMvc.perform(delete("/api/interests/{interestId}", interestId)
                     .header("Monew-Request-User-ID", UUID.randomUUID().toString())
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNoContent());  // 204 No Content (성공적으로 삭제된 경우)
+                .andExpect(status().isNoContent());
 
-            // Verify that the interest was deleted
             verify(interestService).deleteInterest(interestId);
         }
 
         @Test
-        void 존재하지_않는_관심사를_삭제하려고_하면_InterestNotFoundException이_발생한다() throws Exception {
+        void 존재하지_않는_관심사를_삭제하려고_하면_404를_반환한다() throws Exception {
             // Given
             UUID nonExistentInterestId = UUID.randomUUID();
 
@@ -456,7 +455,6 @@ class InterestControllerTest {
                 .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));
 
-            // Verify that the service method was called
             verify(interestService).deleteInterest(nonExistentInterestId);
         }
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
@@ -32,6 +32,9 @@ import java.util.UUID;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -414,6 +417,47 @@ class InterestControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("관심사 삭제 테스트")
+    class InterestDeleteTests {
+
+        @Test
+        void 관심사를_삭제하면_204를_반환한다() throws Exception {
+            // Given
+            UUID interestId = UUID.randomUUID();
+
+            doNothing().when(interestService).deleteInterest(interestId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/interests/{interestId}", interestId)
+                    .header("Monew-Request-User-ID", UUID.randomUUID().toString())
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());  // 204 No Content (성공적으로 삭제된 경우)
+
+            // Verify that the interest was deleted
+            verify(interestService).deleteInterest(interestId);
+        }
+
+        @Test
+        void 존재하지_않는_관심사를_삭제하려고_하면_InterestNotFoundException이_발생한다() throws Exception {
+            // Given
+            UUID nonExistentInterestId = UUID.randomUUID();
+
+            doThrow(new InterestNotFoundException(nonExistentInterestId)).when(interestService).deleteInterest(nonExistentInterestId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/interests/{interestId}", nonExistentInterestId)
+                    .header("Monew-Request-User-ID", UUID.randomUUID().toString())
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));
+
+            // Verify that the service method was called
+            verify(interestService).deleteInterest(nonExistentInterestId);
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
@@ -5,11 +5,8 @@ import com.sprint.mission.sb03monewteam1.config.LoadTestEnv;
 import com.sprint.mission.sb03monewteam1.dto.request.InterestRegisterRequest;
 import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
-import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.fixture.InterestFixture;
-import com.sprint.mission.sb03monewteam1.fixture.SubscriptionFixture;
-import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestKeywordRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.subscription.SubscriptionRepository;
@@ -384,33 +381,15 @@ class InterestIntegrationTest {
     @DisplayName("관심사 삭제 테스트")
     class InterestDeleteTests {
 
-        private User testUser;
-
-        @BeforeEach
-        void setUp() {
-            testUser = User.builder()
-                .nickname("testUser")
-                .email("testuser@example.com")
-                .password("password1234*")
-                .build();
-            userRepository.save(testUser);
-        }
-
         @Test
         void 관심사를_삭제하면_204를_반환한다() throws Exception {
             // Given
             Interest testInterest = InterestFixture.createInterest();
             interestRepository.save(testInterest);
 
-            Subscription subscription = Subscription.builder()
-                .interest(testInterest)
-                .user(testUser)
-                .build();
-            subscriptionRepository.save(subscription);
-
             // When & Then
             mockMvc.perform(delete("/api/interests/{interestId}", testInterest.getId())
-                    .header("Monew-Request-User-ID", testUser.getId().toString())
+                    .header("Monew-Request-User-ID", UUID.randomUUID().toString())
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
         }
@@ -422,7 +401,7 @@ class InterestIntegrationTest {
 
             // When & Then
             mockMvc.perform(delete("/api/interests/{interestId}", nonExistentInterestId)
-                    .header("Monew-Request-User-ID", testUser.getId().toString())
+                    .header("Monew-Request-User-ID", UUID.randomUUID().toString())
                     .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -28,6 +28,7 @@ import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 
 
 import com.sprint.mission.sb03monewteam1.mapper.SubscriptionMapper;
+import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestKeywordRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.subscription.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
@@ -54,6 +55,9 @@ class InterestServiceTest {
     private InterestRepository interestRepository;
 
     @Mock
+    private InterestKeywordRepository interestKeywordRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -77,7 +81,7 @@ class InterestServiceTest {
 
             // Given
             InterestRegisterRequest request = InterestFixture.createInterestRegisterRequest();
-            Interest savedInterest = new Interest();
+            Interest savedInterest = InterestFixture.createInterest();
             InterestDto expectedResponse = InterestFixture.createInterestResponseDto();
 
             given(interestRepository.existsByName(request.name())).willReturn(false);
@@ -122,7 +126,7 @@ class InterestServiceTest {
             InterestRegisterRequest request = InterestFixture.createInterestRegisterRequest();
             InterestRegisterRequest similarRequest = InterestFixture.createInterestRegisterRequestWithSimilarName();
 
-            Interest existingInterest = new Interest();
+            Interest existingInterest = InterestFixture.createInterest();
             existingInterest.setName(request.name());
             given(interestRepository.findAll()).willReturn(List.of(existingInterest));
 
@@ -369,6 +373,8 @@ class InterestServiceTest {
             // Then
             verify(interestRepository).findById(interest.getId());
             verify(interestRepository).delete(interest);
+            verify(interestKeywordRepository).deleteByInterestId(interest.getId());
+            verify(subscriptionRepository).deleteByInterestId(interest.getId());
         }
 
         @Test

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -348,6 +349,43 @@ class InterestServiceTest {
             assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
 
             verify(interestRepository).findById(nonExistentInterestId);
+        }
+    }
+
+    @Nested
+    @DisplayName("관심사 삭제 테스트")
+    class InterestDeleteTests {
+
+        @Test
+        void 관심사를_삭제하면_삭제가_성공한다() {
+            // Given
+            Interest interest = InterestFixture.createInterest();
+
+            when(interestRepository.findById(interest.getId())).thenReturn(Optional.of(interest));
+
+            // When
+            interestService.deleteInterest(interest.getId());
+
+            // Then
+            verify(interestRepository).findById(interest.getId());
+            verify(interestRepository).delete(interest);
+        }
+
+        @Test
+        void 존재하지_않는_관심사를_삭제하면_InterestNotFoundException이_발생한다() {
+            // Given
+            UUID nonExistentInterestId = UUID.randomUUID();
+            when(interestRepository.findById(nonExistentInterestId)).thenReturn(Optional.empty());
+
+            // When & Then
+            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class, () -> {
+                interestService.deleteInterest(nonExistentInterestId);
+            });
+
+            assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
+
+            verify(interestRepository).findById(nonExistentInterestId);
+            verify(interestRepository, times(0)).delete(any());
         }
     }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 관심사 삭제 API 구현

### ✅ 완료한 작업
- [x] 관심사 삭제 API 구현
- [x] 관심사 삭제 통합, 단위 테스트 작성

### 🧪 테스트 결과
- 로컬 테스트 완료

### ⚠️ 기타 참고 사항
- 후속 작업 - 사용자 활동 내역 관심사 삭제 반영 

### Related Issue

Closes #98 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 관심사 삭제 API 엔드포인트(DELETE /api/interests/{interestId})가 추가되었습니다.

* **버그 수정**
  * 관심사 삭제 시 관련 구독 및 키워드도 함께 삭제됩니다.

* **테스트**
  * 관심사 삭제 기능에 대한 단위 및 통합 테스트가 추가되었습니다.

* **리팩터**
  * 엔티티 생성자 및 필드 접근 제한이 강화되어, 불필요한 외부 접근이 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->