### PR TITLE
[feat] [MN-33] 알림 삭제 (스케줄러 버전)

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/NotificationController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/NotificationController.java
@@ -42,6 +42,9 @@ public class NotificationController implements NotificationApi {
         CursorPageResponse<NotificationDto> result = notificationService
             .getUncheckedNotifications(userId, cursor, after, limit);
 
+        log.info("미확인 알림 목록 조회 요청 완료 - userId: {}, cursor: {}, limit: {}",
+            userId, cursor, limit);
+
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -41,7 +41,7 @@ public enum ErrorCode {
     // 알림 관련 예외
     NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송에 실패하였습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
-
+    NOTIFICATION_CLEANUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "확인된 알림 삭제에 실패하였습니다."),
     // 커서 기반 페이지네이션 관련 예외
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 커서 형식입니다."),
     INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST,"잘못된 ID 커서 형식입니다."),

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/notification/NotificationCleanupException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/notification/NotificationCleanupException.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.sb03monewteam1.exception.notification;
+
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import java.util.Map;
+
+public class NotificationCleanupException extends NotificationException {
+
+    public NotificationCleanupException(String message) {
+        super(ErrorCode.NOTIFICATION_CLEANUP_FAILED, Map.of("message", message));
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
@@ -1,10 +1,20 @@
 package com.sprint.mission.sb03monewteam1.repository.jpa.notification;
 
 import com.sprint.mission.sb03monewteam1.entity.Notification;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
 
     long countByUserIdAndIsCheckedFalse(UUID userId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Notification n WHERE n.isChecked = true AND n.createdAt < :threshold")
+    void deleteCheckedNotificationsBefore(@Param("threshold") Instant threshold);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
@@ -16,5 +16,5 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     @Modifying
     @Transactional
     @Query("DELETE FROM Notification n WHERE n.isChecked = true AND n.createdAt < :threshold")
-    void deleteCheckedNotificationsBefore(@Param("threshold") Instant threshold);
+    int deleteCheckedNotificationsBefore(@Param("threshold") Instant threshold);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
@@ -14,7 +14,7 @@ public class NotificationCleanupScheduler {
 
     private final NotificationService notificationService;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 15 0 * * *")
     public void runNotificationCleanupBatch() {
         log.info("확인된 알림 삭제 시작");
         try {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
@@ -1,0 +1,27 @@
+package com.sprint.mission.sb03monewteam1.scheduler;
+
+import com.sprint.mission.sb03monewteam1.exception.notification.NotificationCleanupException;
+import com.sprint.mission.sb03monewteam1.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationCleanupScheduler {
+
+    private final NotificationService notificationService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runNotificationCleanupBatch() {
+        log.info("확인된 알림 삭제 시작");
+        try {
+            notificationService.deleteOldCheckedNotifications();
+        } catch (Exception e) {
+            throw new NotificationCleanupException("확인된 알림 삭제에 실패하였습니다.");
+        }
+    }
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupScheduler.java
@@ -20,6 +20,7 @@ public class NotificationCleanupScheduler {
         try {
             notificationService.deleteOldCheckedNotifications();
         } catch (Exception e) {
+            log.error("확인된 알림 삭제 중 오류 발생");
             throw new NotificationCleanupException("확인된 알림 삭제에 실패하였습니다.");
         }
     }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationService.java
@@ -22,4 +22,6 @@ public interface NotificationService {
         Instant after,
         int limit
     );
+
+    void deleteOldCheckedNotifications();
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -73,6 +73,7 @@ public class NotificationServiceImpl implements NotificationService {
         Instant after,
         int limit
     ) {
+        log.info("알림 목록 조회 요청 - userId:{}, cursor:{}, limit:{}", userId, cursor, limit);
         List<Notification> notifications = notificationRepository
             .findUncheckedNotificationsWithCursor(
                 userId,
@@ -100,6 +101,8 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         Long totalElements = notificationRepository.countByUserIdAndIsCheckedFalse(userId);
+
+        log.info("알림 목록 조회 완료 - userId:{}, cursor:{}, limit:{}", userId, cursor, limit);
 
         return CursorPageResponse.<NotificationDto>builder()
             .content(contents)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -12,6 +12,7 @@ import com.sprint.mission.sb03monewteam1.exception.notification.NotificationNotF
 import com.sprint.mission.sb03monewteam1.mapper.NotificationMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.notification.NotificationRepository;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -130,5 +131,13 @@ public class NotificationServiceImpl implements NotificationService {
         notification.markAsChecked();
 
         log.info("알림 개별 확인 완료: notificationId={}, userId={}", notificationId, requestUserId);
+    }
+
+    @Override
+    public void deleteOldCheckedNotifications() {
+        log.info("자동 확인 알림 삭제 요청");
+        Instant threshold = Instant.now().minus(7, ChronoUnit.DAYS);
+        notificationRepository.deleteCheckedNotificationsBefore(threshold);
+        log.info("자동 확인 알림 삭제 완료");
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -137,7 +137,7 @@ public class NotificationServiceImpl implements NotificationService {
     public void deleteOldCheckedNotifications() {
         log.info("자동 확인 알림 삭제 요청");
         Instant threshold = Instant.now().minus(7, ChronoUnit.DAYS);
-        notificationRepository.deleteCheckedNotificationsBefore(threshold);
-        log.info("자동 확인 알림 삭제 완료");
+        int deleted = notificationRepository.deleteCheckedNotificationsBefore(threshold);
+        log.info("자동 확인 알림 삭제 완료 - 삭제된 알림 갯수: {}", deleted);
     }
 }

--- a/src/main/resources/application-postgres.yaml
+++ b/src/main/resources/application-postgres.yaml
@@ -23,6 +23,10 @@ spring:
     jdbc:
       initialize-schema: always
 
+  data:
+    mongodb:
+      uri: mongodb://mongo_root_user:mongo_root_password@mongo:27017/monew_mongo
+
 logging:
   level:
     root: info

--- a/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupSchedulerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/NotificationCleanupSchedulerTest.java
@@ -1,0 +1,50 @@
+package com.sprint.mission.sb03monewteam1.scheduler;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+
+import com.sprint.mission.sb03monewteam1.exception.notification.NotificationCleanupException;
+import com.sprint.mission.sb03monewteam1.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationCleanupSchedulerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private NotificationCleanupScheduler scheduler;
+
+    @Test
+    void 알림_정리_배치_작업이_실행되면_알림_삭제_서비스가_실행되어야_한다() {
+        // When
+        scheduler.runNotificationCleanupBatch();
+
+        // Then
+        then(notificationService).should(times(1)).deleteOldCheckedNotifications();
+    }
+
+    @Test
+    void 알림_정리_배치_작업_중_오류가_발생하면_500이_반환되어야_한다() {
+        // Given
+        doThrow(new NotificationCleanupException("확인된 알림 삭제에 실패하였습니다.")).when(notificationService)
+            .deleteOldCheckedNotifications();
+
+        // When & Then
+        NotificationCleanupException ex = assertThrows(NotificationCleanupException.class, () -> {
+            scheduler.runNotificationCleanupBatch();
+        });
+
+        assertThat(ex.getMessage()).isEqualTo("확인된 알림 삭제에 실패하였습니다.");
+        assertThat(ex.getErrorCode().getHttpStatus().toString())
+            .isEqualTo("500 INTERNAL_SERVER_ERROR");
+    }
+}

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -27,6 +28,7 @@ import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.mapper.NotificationMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.notification.NotificationRepository;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -345,6 +347,22 @@ public class NotificationServiceTest {
             }).isInstanceOf(NotificationAccessDeniedException.class);
 
             then(notificationRepository).should().findById(notificationId);
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 자동 배치 삭제 테스트")
+    class NotificationAutoDeleteTests {
+
+        @Test
+        void 확인된_알림을_삭제할_수_있다() {
+            // Given
+            Instant threshold = Instant.now().minus(7, ChronoUnit.DAYS);
+
+            willDoNothing().given(notificationRepository).deleteCheckedNotificationsBefore(threshold);
+
+            // When
+            notificationService.deleteOldCheckedNotifications();
         }
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
@@ -332,7 +332,7 @@ public class NotificationServiceTest {
                 Optional.empty());
 
             // when & then
-            Assertions.assertThatThrownBy(() -> {
+            assertThatThrownBy(() -> {
                 notificationService.confirm(invalidNotificationId, userId);
             }).isInstanceOf(NotificationNotFoundException.class);
 


### PR DESCRIPTION
### 📌 작업 개요
- 알림 삭제 기능 구현 (스프링 스케줄러)

### ✅ 완료한 작업
- [x] 알림 삭제 기능 구현
- [x] 스케줄러 및 서비스 테스트 코드 구현

### 🧪 테스트 결과
- 로컬 테스트 완료
- 테스트 코드 통과

### ⚠️ 기타 참고 사항
- 현재 스케줄러로 작업되어 있지만, 스프링 배치로 리팩토링

### Related Issue

Closes #105 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 7일 이상 지난 확인된 알림을 자동으로 삭제하는 스케줄러가 매일 새벽 00:15에 실행됩니다.
  * 알림 정리 실패 시 새로운 예외 처리와 관련 오류 코드가 추가되었습니다.

* **버그 수정**
  * 알림 목록 조회 시 요청 시작과 완료에 대한 추가 로그가 기록됩니다.

* **테스트**
  * 알림 자동 삭제 스케줄러 및 서비스 기능에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->