### PR TITLE
[fix] [MN-67] 알림 ResourceType 대문자로 수정

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/ResourceType.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/ResourceType.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum ResourceType {
-    INTERREST,
+    INTEREST,
     COMMENT
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/ResourceType.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/ResourceType.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum ResourceType {
-    interest,
-    comment
+    INTERREST,
+    COMMENT
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -39,7 +39,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         Notification notification = Notification.builder()
             .content(String.format("%s와 관련된 기사가 %d건 등록되었습니다.", interest.getName(), articleCount))
-            .resourceType(ResourceType.interest)
+            .resourceType(ResourceType.INTERREST)
             .resourceId(interest.getId())
             .user(user)
             .build();
@@ -58,7 +58,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         Notification notification = Notification.builder()
             .content(String.format("%s님이 나의 댓글을 좋아합니다.", user.getNickname()))
-            .resourceType(ResourceType.comment)
+            .resourceType(ResourceType.COMMENT)
             .resourceId(comment.getId())
             .user(comment.getAuthor())
             .build();

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -39,7 +39,7 @@ public class NotificationServiceImpl implements NotificationService {
 
         Notification notification = Notification.builder()
             .content(String.format("%s와 관련된 기사가 %d건 등록되었습니다.", interest.getName(), articleCount))
-            .resourceType(ResourceType.INTERREST)
+            .resourceType(ResourceType.INTEREST)
             .resourceId(interest.getId())
             .user(user)
             .build();

--- a/src/main/resources/application-postgres.yaml
+++ b/src/main/resources/application-postgres.yaml
@@ -23,6 +23,10 @@ spring:
     jdbc:
       initialize-schema: always
 
+  data:
+    mongodb:
+      uri: mongodb://mongo_root_user:mongo_root_password@mongo:27017/monew_mongo
+
 logging:
   level:
     root: info

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/NotificationFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/NotificationFixture.java
@@ -14,7 +14,7 @@ public class NotificationFixture {
 
     private static final UUID DEFAULT_NOTIFICATION_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
     private static final String DEFAULT_CONTENT = "테스트 알림 내용입니다.";
-    private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.interest;
+    private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.INTERREST;
     private static final UUID DEFAULT_RESOURCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
     private static final boolean DEFAULT_IS_CHECKED = false;
     private static final Instant DEFAULT_CREATED_AT = Instant.parse("2024-01-01T00:00:00Z");
@@ -24,7 +24,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification() {
         return Notification.builder()
             .content("관심사에 새 기사가 등록되었습니다.")
-            .resourceType(ResourceType.interest)
+            .resourceType(ResourceType.INTERREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(UserFixture.createUser())
@@ -34,7 +34,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification(User user) {
         return Notification.builder()
             .content("새로운 기사 등록 알림입니다.")
-            .resourceType(ResourceType.interest)
+            .resourceType(ResourceType.INTERREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(user)
@@ -44,7 +44,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification(String content) {
         return Notification.builder()
             .content(content)
-            .resourceType(ResourceType.interest)
+            .resourceType(ResourceType.INTERREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(UserFixture.createUser())
@@ -58,7 +58,7 @@ public class NotificationFixture {
     ) {
         return Notification.builder()
             .content(String.format("%s와 관련된 기사가 %d건 등록되었습니다.", interest.getName(), articleCount))
-            .resourceType(ResourceType.interest)
+            .resourceType(ResourceType.INTERREST)
             .resourceId(interest.getId())
             .isChecked(false)
             .user(user)

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/NotificationFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/NotificationFixture.java
@@ -14,7 +14,7 @@ public class NotificationFixture {
 
     private static final UUID DEFAULT_NOTIFICATION_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
     private static final String DEFAULT_CONTENT = "테스트 알림 내용입니다.";
-    private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.INTERREST;
+    private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.INTEREST;
     private static final UUID DEFAULT_RESOURCE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440001");
     private static final boolean DEFAULT_IS_CHECKED = false;
     private static final Instant DEFAULT_CREATED_AT = Instant.parse("2024-01-01T00:00:00Z");
@@ -24,7 +24,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification() {
         return Notification.builder()
             .content("관심사에 새 기사가 등록되었습니다.")
-            .resourceType(ResourceType.INTERREST)
+            .resourceType(ResourceType.INTEREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(UserFixture.createUser())
@@ -34,7 +34,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification(User user) {
         return Notification.builder()
             .content("새로운 기사 등록 알림입니다.")
-            .resourceType(ResourceType.INTERREST)
+            .resourceType(ResourceType.INTEREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(user)
@@ -44,7 +44,7 @@ public class NotificationFixture {
     public static Notification createNewArticleNotification(String content) {
         return Notification.builder()
             .content(content)
-            .resourceType(ResourceType.INTERREST)
+            .resourceType(ResourceType.INTEREST)
             .resourceId(UUID.randomUUID())
             .isChecked(false)
             .user(UserFixture.createUser())
@@ -58,7 +58,7 @@ public class NotificationFixture {
     ) {
         return Notification.builder()
             .content(String.format("%s와 관련된 기사가 %d건 등록되었습니다.", interest.getName(), articleCount))
-            .resourceType(ResourceType.INTERREST)
+            .resourceType(ResourceType.INTEREST)
             .resourceId(interest.getId())
             .isChecked(false)
             .user(user)

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/NotificationIntegrationTest.java
@@ -155,7 +155,7 @@ public class NotificationIntegrationTest {
                 .untilAsserted(() -> {
                     Notification notification = notificationRepository.findAll().get(0);
                     assertThat(notification.getUser().getId()).isEqualTo(author.getId());
-                    assertThat(notification.getResourceType()).isEqualTo(ResourceType.comment);
+                    assertThat(notification.getResourceType()).isEqualTo(ResourceType.COMMENT);
                     assertThat(notification.getResourceId()).isEqualTo(comment.getId());
                     assertThat(notification.getContent()).contains(liker.getNickname());
                 });
@@ -220,7 +220,7 @@ public class NotificationIntegrationTest {
                     List<Notification> notifications = notificationRepository.findAll();
                     assertThat(notifications.size()).isEqualTo(3);
                     assertThat(notifications.get(0).getResourceType()).isEqualTo(
-                        ResourceType.interest);
+                        ResourceType.INTERREST);
                     assertThat(notifications.get(0).getUser().getId()).isEqualTo(user1.getId());
                 });
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/NotificationIntegrationTest.java
@@ -220,7 +220,7 @@ public class NotificationIntegrationTest {
                     List<Notification> notifications = notificationRepository.findAll();
                     assertThat(notifications.size()).isEqualTo(3);
                     assertThat(notifications.get(0).getResourceType()).isEqualTo(
-                        ResourceType.INTERREST);
+                        ResourceType.INTEREST);
                     assertThat(notifications.get(0).getUser().getId()).isEqualTo(user1.getId());
                 });
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
@@ -123,7 +123,7 @@ public class NotificationServiceTest {
 
             Notification saved = captor.getValue();
             assertThat(saved.getUser().getId()).isEqualTo(comment.getAuthor().getId());
-            assertThat(saved.getResourceType()).isEqualTo(ResourceType.comment);
+            assertThat(saved.getResourceType()).isEqualTo(ResourceType.COMMENT);
             assertThat(saved.getResourceId()).isEqualTo(commentId);
             assertThat(saved.getContent()).isEqualTo(expectedContent);
         }


### PR DESCRIPTION
### 📌 작업 개요
- 알림 ResourceType 대문자로 수정

### ✅ 완료한 작업
- [x] 알림 ResourceType 대문자로 수정

### 🧪 테스트 결과
- 로컬 환경에서 실행 완료

### ⚠️ 기타 참고 사항
- 아직 남은 작업이나, 리뷰어가 확인해야 할 이슈

### Related Issue

Closes #108 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 알림 관련 기능에서 리소스 타입(enum) 명칭을 소문자에서 대문자로 수정하여 일관성을 높였습니다. (예: interest → INTEREST, comment → COMMENT)

* **테스트**
  * 리소스 타입 명칭 변경에 따라 관련 테스트 코드의 기대값을 대문자 명칭으로 수정하였습니다.

* **환경설정**
  * PostgreSQL 프로파일에 MongoDB 연결 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->