### PR TITLE
[refactor] [MN-70] 알림 전체 확인_일괄 업데이트로 리팩토링

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
@@ -4,10 +4,22 @@ import com.sprint.mission.sb03monewteam1.entity.Notification;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
 
     long countByUserIdAndIsCheckedFalse(UUID userId);
 
     List<Notification> findByUserIdAndIsCheckedFalse(UUID userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Notification n
+          SET n.isChecked = true
+        WHERE n.user.id = :userId
+          AND n.isChecked = false
+      """)
+    int markAllAsCheckedByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceImpl.java
@@ -141,10 +141,8 @@ public class NotificationServiceImpl implements NotificationService {
             throw new UserNotFoundException(userId);
         }
 
-        List<Notification> notifications = notificationRepository.findByUserIdAndIsCheckedFalse(userId);
+        int updatedCount = notificationRepository.markAllAsCheckedByUserId(userId);
 
-        notifications.forEach(Notification::markAsChecked);
-
-        log.info("알림 전체 확인 완료: userId={}, 확인된 알림 수={}", userId, notifications.size());
+        log.info("알림 전체 확인 완료: userId={}, 확인된 알림 수={}", userId, updatedCount);
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/NotificationServiceTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -378,13 +377,13 @@ public class NotificationServiceTest {
             }
 
             given(userRepository.existsByIdAndIsDeletedFalse(userId)).willReturn(true);
-            given(notificationRepository.findByUserIdAndIsCheckedFalse(userId)).willReturn(notifications);
+            given(notificationRepository.markAllAsCheckedByUserId(userId)).willReturn(5);
 
             // when
             notificationService.confirmAll(userId);
 
             // then
-            assertThat(notifications).allMatch(Notification::isChecked);
+            then(notificationRepository).should().markAllAsCheckedByUserId(userId);
         }
 
         @Test
@@ -394,7 +393,7 @@ public class NotificationServiceTest {
             UUID userId = UUID.randomUUID();
 
             given(userRepository.existsByIdAndIsDeletedFalse(userId)).willReturn(true);
-            given(notificationRepository.findByUserIdAndIsCheckedFalse(userId)).willReturn(List.of());
+            given(notificationRepository.markAllAsCheckedByUserId(userId)).willReturn(0);
 
             // when & then
             assertThatCode(() -> notificationService.confirmAll(userId))


### PR DESCRIPTION
### 📌 작업 개요
- 알림 전체 확인 로직을 반복 처리 방식에서 JPQL 일괄 업데이트 방식으로 리팩토링

### ✅ 완료한 작업
- [x] JPQL 벌크 업데이트 쿼리 작성
- [x] NotificationService.confirmAll() 로직 수정
- [x] 관련 서비스 테스트 코드 수정 및 검증

### 🧪 테스트 결과
- 테스트 코드 통과
- 로컬 환경 테스트 완료

### ⚠️ 기타 참고 사항


### Related Issue

Closes #111 
