### PR TITLE
[feat] [MN-49] 관심사 구독 취소 API

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
@@ -25,7 +25,7 @@ public class InterestController implements InterestApi {
 
     @Override
     @PostMapping
-    public ResponseEntity<InterestDto> create(
+    public ResponseEntity<InterestDto> createInterest(
         @RequestBody @Valid InterestRegisterRequest request) {
 
         log.info("관심사 등록 요청: {}", request);
@@ -80,7 +80,8 @@ public class InterestController implements InterestApi {
 
         log.info("관심사 수정 요청: interestId={}, request={}", interestId, request);
 
-        InterestDto updatedInterestDto = interestService.updateInterestKeywords(interestId, request, userId);
+        InterestDto updatedInterestDto = interestService.updateInterestKeywords(interestId, request,
+            userId);
 
         log.info("관심사 수정 완료: response={}", updatedInterestDto);
 
@@ -89,7 +90,8 @@ public class InterestController implements InterestApi {
 
 
     @DeleteMapping("/{interestId}")
-    public ResponseEntity<Void> deleteInterest(@PathVariable UUID interestId) {
+    public ResponseEntity<Void> deleteInterest(
+        @PathVariable UUID interestId) {
 
         log.info("관심사 삭제 요청: interestId={}", interestId);
 
@@ -101,11 +103,16 @@ public class InterestController implements InterestApi {
     }
 
     @DeleteMapping("/{interestId}/subscriptions")
-    @ResponseStatus(HttpStatus.OK)
-    public void deleteSubscription(
+    public ResponseEntity<Void> deleteSubscription(
         @PathVariable UUID interestId,
-        @RequestHeader("Monew-Request-User-ID") UUID userId
-    ) {
+        @RequestHeader("Monew-Request-User-ID") UUID userId) {
+
+        log.info("구독 삭제 요청: interestId={}, userId={}", interestId, userId);
+
         interestService.deleteSubscription(userId, interestId);
+
+        log.info("구독 삭제 완료: interestId={}, userId={}", interestId, userId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/InterestController.java
@@ -99,4 +99,13 @@ public class InterestController implements InterestApi {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @DeleteMapping("/{interestId}/subscriptions")
+    @ResponseStatus(HttpStatus.OK)
+    public void deleteSubscription(
+        @PathVariable UUID interestId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId
+    ) {
+        interestService.deleteSubscription(userId, interestId);
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/InterestApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/InterestApi.java
@@ -65,7 +65,8 @@ public interface InterestApi {
             )
         )
     })
-    ResponseEntity<InterestDto> create(InterestRegisterRequest interestRegisterRequest);
+    ResponseEntity<InterestDto> createInterest(
+        InterestRegisterRequest interestRegisterRequest);
 
     @Operation(summary = "관심사 목록 조회", description = "사용자가 관심사 목록을 조회합니다.")
     @ApiResponses({
@@ -100,8 +101,7 @@ public interface InterestApi {
         @RequestParam(defaultValue = "") String cursor,
         @RequestParam(defaultValue = "10") int limit,
         @RequestParam(defaultValue = "subscriberCount") String orderBy,
-        @RequestParam(defaultValue = "DESC") String direction
-    );
+        @RequestParam(defaultValue = "DESC") String direction);
 
     @Operation(summary = "관심사 구독", description = "사용자가 특정 관심사를 구독합니다.")
     @ApiResponses({
@@ -132,8 +132,7 @@ public interface InterestApi {
     })
     ResponseEntity<SubscriptionDto> createSubscription(
         @PathVariable UUID interestId,
-        @RequestHeader("Monew-Request-User-ID") UUID userId
-    );
+        @RequestHeader("Monew-Request-User-ID") UUID userId);
 
     @Operation(summary = "관심사 수정", description = "사용자가 관심사를 수정합니다.")
     @ApiResponses({
@@ -173,8 +172,7 @@ public interface InterestApi {
     ResponseEntity<InterestDto> updateInterestKeywords(
         @PathVariable UUID interestId,
         @RequestBody InterestUpdateRequest request,
-        @RequestHeader("Monew-Request-User-ID") UUID userId
-    );
+        @RequestHeader("Monew-Request-User-ID") UUID userId);
 
     @Operation(summary = "관심사 삭제", description = "사용자가 특정 관심사를 삭제합니다.")
     @ApiResponses({
@@ -200,5 +198,34 @@ public interface InterestApi {
             )
         )
     })
-    ResponseEntity<Void> deleteInterest(@PathVariable UUID interestId);
+    ResponseEntity<Void> deleteInterest(
+        @PathVariable UUID interestId);
+
+    @Operation(summary = "관심사 구독 취소", description = "사용자가 특정 관심사에 대한 구독을 취소합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "204",
+            description = "구독 취소 성공",
+            content = @Content(mediaType = "application/json")
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "관심사 또는 구독 정보가 존재하지 않음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<Void> deleteSubscription(
+        @PathVariable UUID interestId,
+        @RequestHeader("Monew-Request-User-ID") UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INTEREST_SIMILARITY_ERROR(HttpStatus.CONFLICT, "유사한 관심사 이름이 존재합니다."),
     INTEREST_DUPLICATE(HttpStatus.CONFLICT, "이미 존재하는 관심사입니다."),
     INTEREST_NOT_FOUND(HttpStatus.NOT_FOUND, "관심사를 찾을 수 없습니다."),
+    SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "구독 정보를 찾을 수 없습니다."),
 
     // 기사 관련 예외
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "기사를 찾을 수 없습니다."),
@@ -42,6 +43,7 @@ public enum ErrorCode {
     NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송에 실패하였습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     NOTIFICATION_CLEANUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "확인된 알림 삭제에 실패하였습니다."),
+
     // 커서 기반 페이지네이션 관련 예외
     INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 커서 형식입니다."),
     INVALID_CURSOR_ID(HttpStatus.BAD_REQUEST,"잘못된 ID 커서 형식입니다."),

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/interest/SubscriptionNotFoundException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/interest/SubscriptionNotFoundException.java
@@ -7,7 +7,8 @@ import java.util.UUID;
 
 public class SubscriptionNotFoundException extends CustomException {
 
-  public SubscriptionNotFoundException(UUID interestId, UUID userId) {
-    super(ErrorCode.SUBSCRIPTION_NOT_FOUND, Map.of("interestID", String.valueOf(interestId), "userId", String.valueOf(userId)));
-  }
+    public SubscriptionNotFoundException(UUID interestId, UUID userId) {
+        super(ErrorCode.SUBSCRIPTION_NOT_FOUND,
+            Map.of("interestID", String.valueOf(interestId), "userID", String.valueOf(userId)));
+    }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/exception/interest/SubscriptionNotFoundException.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/exception/interest/SubscriptionNotFoundException.java
@@ -1,0 +1,13 @@
+package com.sprint.mission.sb03monewteam1.exception.interest;
+
+import com.sprint.mission.sb03monewteam1.exception.CustomException;
+import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
+import java.util.Map;
+import java.util.UUID;
+
+public class SubscriptionNotFoundException extends CustomException {
+
+  public SubscriptionNotFoundException(UUID interestId, UUID userId) {
+    super(ErrorCode.SUBSCRIPTION_NOT_FOUND, Map.of("interestID", String.valueOf(interestId), "userId", String.valueOf(userId)));
+  }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
@@ -24,7 +24,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.user WHERE s.interest.id = :interestId")
     List<Subscription> findAllByInterestIdFetchUser(@Param("interestId") UUID interestId);
 
-    boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+    boolean findByUserIdAndInterestId(UUID userId, UUID interestId);
 
     @Transactional
     void deleteByInterestId(UUID interestId);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/subscription/SubscriptionRepository.java
@@ -24,7 +24,9 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, UUID
     @Query("SELECT s FROM Subscription s LEFT JOIN FETCH s.user WHERE s.interest.id = :interestId")
     List<Subscription> findAllByInterestIdFetchUser(@Param("interestId") UUID interestId);
 
-    boolean findByUserIdAndInterestId(UUID userId, UUID interestId);
+    boolean existsByUserIdAndInterestId(UUID userId, UUID interestId);
+
+    Optional<Subscription> findByUserIdAndInterestId(UUID userId, UUID interestId);
 
     @Transactional
     void deleteByInterestId(UUID interestId);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestService.java
@@ -24,4 +24,6 @@ public interface InterestService {
     InterestDto updateInterestKeywords(UUID interestId, InterestUpdateRequest request, UUID userId);
 
     void deleteInterest(UUID interestId);
+
+    void deleteSubscription(UUID userId, UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -33,7 +33,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.similarity.LevenshteinDistance;
-import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -205,7 +204,7 @@ public class InterestServiceImpl implements InterestService {
             interest.getKeywords().add(interestKeyword);
         }
 
-        boolean subscribedByMe = subscriptionRepository.existsByUserIdAndInterestId(userId, interestId);
+        boolean subscribedByMe = subscriptionRepository.findByUserIdAndInterestId(userId, interestId);
 
         Interest updatedInterest = interestRepository.save(interest);
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
@@ -557,7 +557,7 @@ class InterestControllerTest {
     class DeleteSubscriptionTests {
 
         @Test
-        void 관심사_구독을_취소하면_200을_반환한다() throws Exception {
+        void 관심사_구독을_취소하면_204를_반환한다() throws Exception {
             // Given
             UUID userId = UUID.randomUUID();
             UUID interestId = UUID.randomUUID();
@@ -568,7 +568,7 @@ class InterestControllerTest {
             mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
                     .header("Monew-Request-User-ID", userId.toString())
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
             verify(interestService).deleteSubscription(userId, interestId);
         }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/InterestControllerTest.java
@@ -551,4 +551,46 @@ class InterestControllerTest {
             verify(interestService).deleteInterest(nonExistentInterestId);
         }
     }
+
+    @Nested
+    @DisplayName("관심사 구독 취소 테스트")
+    class DeleteSubscriptionTests {
+
+        @Test
+        void 관심사_구독을_취소하면_200을_반환한다() throws Exception {
+            // Given
+            UUID userId = UUID.randomUUID();
+            UUID interestId = UUID.randomUUID();
+
+            doNothing().when(interestService).deleteSubscription(userId, interestId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+                    .header("Monew-Request-User-ID", userId.toString())
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            verify(interestService).deleteSubscription(userId, interestId);
+        }
+
+        @Test
+        void 존재하지_않는_관심사의_구독을_취소하면_404를_반환한다() throws Exception {
+            // Given
+            UUID userId = UUID.randomUUID();
+            UUID interestId = UUID.randomUUID();
+
+            doThrow(new InterestNotFoundException(interestId))
+                .when(interestService).deleteSubscription(userId, interestId);
+
+            // When & Then
+            mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interestId)
+                    .header("Monew-Request-User-ID", userId.toString())
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));
+
+            verify(interestService).deleteSubscription(userId, interestId);
+        }
+    }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
@@ -498,12 +498,12 @@ class InterestIntegrationTest {
         }
 
         @Test
-        void 관심사_구독을_취소하면_200을_반환하고_구독자수가_감소한다() throws Exception {
+        void 관심사_구독을_취소하면_204를_반환하고_구독자수가_감소한다() throws Exception {
             // When & Then
             mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interest.getId())
                     .header("Monew-Request-User-ID", user.getId())
                     .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isNoContent());
 
             // Then
             boolean exists = subscriptionRepository.findByUserIdAndInterestId(user.getId(),
@@ -515,7 +515,7 @@ class InterestIntegrationTest {
         }
 
         @Test
-        void 존재하지_않는_관심사에_대한_구독_취소는_404를_반환한다() throws Exception {
+        void 존재하지_않는_관심사에_대해_구독_취소하면_404를_반환한다() throws Exception {
             // Given
             UUID nonExistentInterestId = UUID.randomUUID();
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/InterestIntegrationTest.java
@@ -6,6 +6,7 @@ import com.sprint.mission.sb03monewteam1.dto.request.InterestRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.InterestUpdateRequest;
 import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
+import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.fixture.InterestFixture;
 import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
@@ -467,6 +468,62 @@ class InterestIntegrationTest {
             mockMvc.perform(delete("/api/interests/{interestId}", nonExistentInterestId)
                     .header("Monew-Request-User-ID", UUID.randomUUID().toString())
                     .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("관심사 구독 취소 테스트")
+    class DeleteSubscriptionTests {
+
+        private Interest interest;
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            interest = interestRepository.save(InterestFixture.createInterest());
+
+            user = userRepository.save(UserFixture.createUser());
+
+            subscriptionRepository.save(
+                Subscription.builder()
+                    .user(user)
+                    .interest(interest)
+                    .build()
+            );
+
+            interest.setSubscriberCount(1L);
+        }
+
+        @Test
+        void 관심사_구독을_취소하면_200을_반환하고_구독자수가_감소한다() throws Exception {
+            // When & Then
+            mockMvc.perform(delete("/api/interests/{interestId}/subscriptions", interest.getId())
+                    .header("Monew-Request-User-ID", user.getId())
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+            // Then
+            boolean exists = subscriptionRepository.findByUserIdAndInterestId(user.getId(),
+                interest.getId()).isPresent();
+            assertThat(exists).isFalse();
+
+            Interest updatedInterest = interestRepository.findById(interest.getId()).orElseThrow();
+            assertThat(updatedInterest.getSubscriberCount()).isEqualTo(0L);
+        }
+
+        @Test
+        void 존재하지_않는_관심사에_대한_구독_취소는_404를_반환한다() throws Exception {
+            // Given
+            UUID nonExistentInterestId = UUID.randomUUID();
+
+            // When & Then
+            mockMvc.perform(
+                    delete("/api/interests/{interestId}/subscriptions", nonExistentInterestId)
+                        .header("Monew-Request-User-ID", user.getId())
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("INTEREST_NOT_FOUND"))
                 .andExpect(jsonPath("$.message").value("관심사를 찾을 수 없습니다."));

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/InterestServiceTest.java
@@ -26,6 +26,7 @@ import com.sprint.mission.sb03monewteam1.exception.interest.InterestDuplicateExc
 import com.sprint.mission.sb03monewteam1.exception.interest.InterestNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.interest.InterestSimilarityException;
 import com.sprint.mission.sb03monewteam1.fixture.InterestFixture;
+import com.sprint.mission.sb03monewteam1.fixture.UserFixture;
 import com.sprint.mission.sb03monewteam1.mapper.InterestMapper;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 
@@ -167,7 +168,8 @@ class InterestServiceTest {
 
             List<Interest> interests = Arrays.asList(interest2, interest1);
 
-            when(interestRepository.searchByKeywordOrName(null, null, limit + 1, orderBy, direction))
+            when(
+                interestRepository.searchByKeywordOrName(null, null, limit + 1, orderBy, direction))
                 .thenReturn(interests);
 
             Subscription subscription1 = Subscription.builder()
@@ -184,7 +186,8 @@ class InterestServiceTest {
                 .thenReturn(Arrays.asList(subscription1, subscription2));
 
             // When
-            CursorPageResponse<InterestDto> result = interestService.getInterests(user.getId(), null, null, limit, orderBy, direction);
+            CursorPageResponse<InterestDto> result = interestService.getInterests(user.getId(),
+                null, null, limit, orderBy, direction);
 
             // Then
             assertThat(result.content()).hasSize(2);
@@ -192,7 +195,8 @@ class InterestServiceTest {
             assertThat(result.content().get(1).name()).isEqualTo("aesthetic");
             assertThat(result.hasNext()).isFalse();
 
-            verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy, direction);
+            verify(interestRepository).searchByKeywordOrName(null, null, limit + 1, orderBy,
+                direction);
             verify(subscriptionRepository).findAllByUserId(user.getId());
         }
 
@@ -205,25 +209,29 @@ class InterestServiceTest {
             String direction = "asc";
 
             Interest interest1 = Interest.builder().name("soccer").subscriberCount(15L).build();
-            Interest interest2 = Interest.builder().name("basketball").subscriberCount(100L).build();
+            Interest interest2 = Interest.builder().name("basketball").subscriberCount(100L)
+                .build();
 
             List<Interest> interests = Arrays.asList(interest1);
             List<InterestDto> interestDtos = Arrays.asList(
                 InterestDto.builder().name("soccer").subscriberCount(150L).build()
             );
 
-            when(interestRepository.searchByKeywordOrName(eq(keyword), eq(null), eq(limit + 1), eq(orderBy), eq(direction)))
+            when(interestRepository.searchByKeywordOrName(eq(keyword), eq(null), eq(limit + 1),
+                eq(orderBy), eq(direction)))
                 .thenReturn(interests);
 
             // When
-            CursorPageResponse<InterestDto> result = interestService.getInterests(UUID.randomUUID(),keyword, null, limit, orderBy, direction);
+            CursorPageResponse<InterestDto> result = interestService.getInterests(UUID.randomUUID(),
+                keyword, null, limit, orderBy, direction);
 
             // Then
             assertThat(result.content()).hasSize(1);
             assertThat(result.content().get(0).name()).isEqualTo("soccer");
             assertThat(result.hasNext()).isFalse();
 
-            verify(interestRepository).searchByKeywordOrName(eq(keyword), eq(null), eq(limit + 1), eq(orderBy), eq(direction));
+            verify(interestRepository).searchByKeywordOrName(eq(keyword), eq(null), eq(limit + 1),
+                eq(orderBy), eq(direction));
         }
 
 
@@ -243,11 +251,13 @@ class InterestServiceTest {
                 InterestDto.builder().name("soccer").subscriberCount(200L).build()
             );
 
-            when(interestRepository.searchByKeywordOrName(eq(null), eq(null), eq(limit + 1), eq(orderBy), eq(direction)))
+            when(interestRepository.searchByKeywordOrName(eq(null), eq(null), eq(limit + 1),
+                eq(orderBy), eq(direction)))
                 .thenReturn(interests);
 
             // When
-            CursorPageResponse<InterestDto> result = interestService.getInterests(UUID.randomUUID(),null, null, limit, orderBy, direction);
+            CursorPageResponse<InterestDto> result = interestService.getInterests(UUID.randomUUID(),
+                null, null, limit, orderBy, direction);
 
             // Then
             assertThat(result.content()).hasSize(2);
@@ -255,7 +265,8 @@ class InterestServiceTest {
             assertThat(result.content().get(1).name()).isEqualTo("soccer");
             assertThat(result.hasNext()).isFalse();
 
-            verify(interestRepository).searchByKeywordOrName(eq(null), eq(null), eq(limit + 1), eq(orderBy), eq(direction));
+            verify(interestRepository).searchByKeywordOrName(eq(null), eq(null), eq(limit + 1),
+                eq(orderBy), eq(direction));
         }
 
         @Test
@@ -267,7 +278,9 @@ class InterestServiceTest {
             String direction = "asc";
 
             // When
-            Throwable throwable = catchThrowable(() -> interestService.getInterests(UUID.randomUUID(), keyword, null, limit, orderBy, direction));
+            Throwable throwable = catchThrowable(
+                () -> interestService.getInterests(UUID.randomUUID(), keyword, null, limit, orderBy,
+                    direction));
 
             // Then
             assertThat(throwable).isInstanceOf(InvalidSortOptionException.class)
@@ -287,7 +300,9 @@ class InterestServiceTest {
             String cursor = "invalidCursorFormat";
 
             // When
-            Throwable throwable = catchThrowable(() -> interestService.getInterests(UUID.randomUUID(), keyword, cursor, limit, orderBy, direction));
+            Throwable throwable = catchThrowable(
+                () -> interestService.getInterests(UUID.randomUUID(), keyword, cursor, limit,
+                    orderBy, direction));
 
             // Then
             assertThat(throwable).isInstanceOf(InvalidCursorException.class)
@@ -330,14 +345,16 @@ class InterestServiceTest {
             when(subscriptionMapper.toDto(subscription)).thenReturn(expectedDto);
 
             // When
-            SubscriptionDto result = interestService.createSubscription(interest.getId(), user.getId());
+            SubscriptionDto result = interestService.createSubscription(interest.getId(),
+                user.getId());
 
             // Then
             assertThat(result).isNotNull();
             assertThat(interest.getSubscriberCount()).isEqualTo(151L);
             assertThat(result.interestId()).isEqualTo(expectedDto.interestId());
             assertThat(result.interestName()).isEqualTo(expectedDto.interestName());
-            assertThat(result.interestSubscriberCount()).isEqualTo(expectedDto.interestSubscriberCount());
+            assertThat(result.interestSubscriberCount()).isEqualTo(
+                expectedDto.interestSubscriberCount());
             assertThat(result.createdAt()).isEqualTo(expectedDto.createdAt());
             verify(interestRepository).findById(interest.getId());
             verify(eventPublisher).publishEvent(any(SubscriptionActivityCreateEvent.class));
@@ -355,9 +372,10 @@ class InterestServiceTest {
             when(interestRepository.findById(nonExistentInterestId)).thenReturn(Optional.empty());
 
             // When & Then
-            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class, () -> {
-                interestService.createSubscription(user.getId(), nonExistentInterestId);
-            });
+            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class,
+                () -> {
+                    interestService.createSubscription(user.getId(), nonExistentInterestId);
+                });
 
             assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
 
@@ -400,13 +418,16 @@ class InterestServiceTest {
 
             InterestUpdateRequest request = new InterestUpdateRequest(newKeywords);
 
-            given(interestRepository.findById(interestId)).willReturn(Optional.of(existingInterest));
-            given(subscriptionRepository.existsByUserIdAndInterestId(userId, interestId)).willReturn(true);
+            given(interestRepository.findById(interestId)).willReturn(
+                Optional.of(existingInterest));
+            given(subscriptionRepository.findByUserIdAndInterestId(userId, interestId)).willReturn(
+                true);
             given(interestRepository.save(existingInterest)).willReturn(updatedInterest);
             given(interestMapper.toDto(updatedInterest, true)).willReturn(expectedResponse);
 
             // When
-            InterestDto result = interestService.updateInterestKeywords(interestId, request, userId);
+            InterestDto result = interestService.updateInterestKeywords(interestId, request,
+                userId);
 
             // Then
             assertThat(result)
@@ -422,7 +443,6 @@ class InterestServiceTest {
         }
 
 
-
         @Test
         void 존재하지_않는_관심사를_수정하려_하면_InterestNotFoundException이_발생한다() {
             // Given
@@ -435,9 +455,10 @@ class InterestServiceTest {
             given(interestRepository.findById(nonExistentInterestId)).willReturn(Optional.empty());
 
             // When & Then
-            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class, () -> {
-                interestService.updateInterestKeywords(nonExistentInterestId, request, userId);
-            });
+            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class,
+                () -> {
+                    interestService.updateInterestKeywords(nonExistentInterestId, request, userId);
+                });
 
             assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
 
@@ -473,14 +494,60 @@ class InterestServiceTest {
             when(interestRepository.findById(nonExistentInterestId)).thenReturn(Optional.empty());
 
             // When & Then
-            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class, () -> {
-                interestService.deleteInterest(nonExistentInterestId);
-            });
+            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class,
+                () -> {
+                    interestService.deleteInterest(nonExistentInterestId);
+                });
 
             assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
 
             verify(interestRepository).findById(nonExistentInterestId);
             verify(interestRepository, times(0)).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("관심사 구독 취소 테스트")
+    class InterestUnsubscribeTests {
+
+        @Test
+        void 관심사_구독을_취소하면_구독이_삭제된다() {
+            // Given
+            Interest interest = InterestFixture.createInterest();
+            User user = UserFixture.createUser();
+
+            Subscription subscription = new Subscription(interest, user);
+
+            when(interestRepository.findById(interest.getId())).thenReturn(Optional.of(interest));
+            given(subscriptionRepository.findByUserIdAndInterestId(user.getId(),
+                interest.getId())).willReturn(true);
+
+            // When
+            interestService.deleteSubscription(interest.getId(), user.getId());
+
+            // Then
+            verify(subscriptionRepository).delete(subscription);
+            assertThat(interest.getSubscriberCount()).isEqualTo(interest.getSubscriberCount() - 1);
+            verify(interestRepository).findById(interest.getId());
+        }
+
+        @Test
+        void 존재하지_않는_관심사이면_예외가_발생한다() {
+            // Given
+            UUID nonExistentInterestId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            when(interestRepository.findById(nonExistentInterestId)).thenReturn(Optional.empty());
+
+            // When
+            InterestNotFoundException exception = assertThrows(InterestNotFoundException.class,
+                () -> {
+                    interestService.deleteSubscription(nonExistentInterestId);
+                });
+
+            // Then
+            assertThat(exception).hasMessageContaining("관심사를 찾을 수 없습니다.");
+            verify(interestRepository).findById(nonExistentInterestId);
         }
     }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 관심사 구독 취소 API 구현

### ✅ 완료한 작업
- [x]  관심사 구독 취소 기능 구현
- [x] 관심사 구독 취소 테스트 코드 작성

### 🧪 테스트 결과
- 로컬 테스트 완료
- 테스트 코드 통과

### ⚠️ 기타 참고 사항


### Related Issue

Closes #117 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 관심사 구독 취소(DELETE /api/interests/{interestId}/subscriptions) 엔드포인트가 추가되어 사용자가 특정 관심사 구독을 직접 취소할 수 있습니다.

* **버그 수정**
  * 구독 정보가 존재하지 않을 때 적절한 오류 메시지와 상태 코드(404)를 반환하도록 개선되었습니다.

* **테스트**
  * 관심사 구독 취소 기능 및 예외 상황에 대한 단위 테스트와 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->