### PR TITLE
[feat] [MN-46] 로그 메시지 및 응답 헤더 관리

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfig.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfig.java
@@ -1,0 +1,88 @@
+package com.sprint.mission.sb03monewteam1.batch.job;
+
+import com.sprint.mission.sb03monewteam1.util.S3Util;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class LogBackupJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final S3Util s3Util;
+
+    @Value("${aws.s3.bucket:}")
+    private String backupBucket;
+
+    @Value("${aws.s3.log-prefix:logs}")
+    private String logPrefix;
+
+    @Value("${logDir:logs}")
+    private String logDir;
+
+    @Bean
+    public Job logBackupJob() {
+        return new JobBuilder("logBackupJob", jobRepository)
+            .start(logBackupStep())
+            .build();
+    }
+
+    @Bean
+    public Step logBackupStep() {
+        return new StepBuilder("logBackupStep", jobRepository)
+            .tasklet(logBackupTasklet(), transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Tasklet logBackupTasklet() {
+        return (contribution, chunkContext) -> {
+            LocalDate targetDate = LocalDate.now().minusDays(1);
+            String dateStr = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            try (Stream<Path> files = Files.list(Paths.get(logDir))) {
+                files.filter(Files::isRegularFile)
+                    .filter(path -> {
+                        String name = path.getFileName().toString();
+                        return (name.startsWith("main-" + dateStr) || name.startsWith(
+                            "debug-" + dateStr))
+                            && name.endsWith(".log.gz");
+                    })
+                    .forEach(path -> uploadFile(targetDate, path));
+            }
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    private void uploadFile(LocalDate date, Path path) {
+        String subDir = path.getFileName().toString().startsWith("main-") ? "json" : "debug";
+        String key = String.format("%s/%s/%s/%s", logPrefix, subDir,
+            date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")),
+            path.getFileName());
+        try (InputStream is = Files.newInputStream(path)) {
+            s3Util.upload(backupBucket, key, is, Files.size(path), "application/gzip");
+            log.info("로그 백업 성공: {} -> {}", path, key);
+        } catch (Exception e) {
+            log.error("로그 백업 실패: {}", path, e);
+        }
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectScheduler.java
@@ -24,14 +24,14 @@ public class ArticleCollectScheduler {
     private final Job naverNewsCollectJob;
     private final Job hankyungNewsCollectJob;
 
-    //    @Scheduled(cron = "0 0 * * * *")
-    @Scheduled(cron = "0 */3 * * * *")
+    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "0 */3 * * * *")
     public void runNaverNewsCollectJob() {
         runJobIfNotRunning("naverNewsCollectJob", naverNewsCollectJob);
     }
 
-    //    @Scheduled(cron = "0 0 * * * *")
-    @Scheduled(cron = "0 */3 * * * *")
+    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "0 */3 * * * *")
     public void runHankyungNewsCollectJob() {
         runJobIfNotRunning("hankyungNewsCollectJob", hankyungNewsCollectJob);
     }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,10 +17,14 @@ public class LogBackupScheduler {
 
     private final JobLauncher jobLauncher;
     private final Job logBackupJob;
+    private final JobExplorer jobExplorer;
 
-    //    @Scheduled(cron = "0 0 3 * * *")
-    @Scheduled(cron = "*/30 * * * * *")
+    @Scheduled(cron = "0 0 3 * * *")
     public void runLogBackupJob() {
+        if (!jobExplorer.findRunningJobExecutions("logBackupJob").isEmpty()) {
+            log.warn("로그 백업 작업이 아직 실행 중이므로 이번 실행은 건너뜁니다.");
+            return;
+        }
         log.info("스케줄러: 로그 백업 배치 잡 실행 요청");
         try {
             JobParameters params = new JobParametersBuilder()

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
@@ -1,0 +1,33 @@
+package com.sprint.mission.sb03monewteam1.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogBackupScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job logBackupJob;
+
+    //    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "*/30 * * * * *")
+    public void runLogBackupJob() {
+        log.info("스케줄러: 로그 백업 배치 잡 실행 요청");
+        try {
+            JobParameters params = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+            jobLauncher.run(logBackupJob, params);
+        } catch (Exception e) {
+            log.error("로그 백업 배치 실행 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,3 +74,4 @@ aws:
     access-key: ${AWS_S3_ACCESS_KEY}
     secret-key: ${AWS_S3_SECRET_KEY}
     backup-prefix: articles/    # S3 저장 경로
+    log-prefix: logs/    # 로그 백업 경로

--- a/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfigTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfigTest.java
@@ -1,0 +1,152 @@
+package com.sprint.mission.sb03monewteam1.batch.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.sprint.mission.sb03monewteam1.util.S3Util;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.transaction.PlatformTransactionManager;
+
+class LogBackupJobConfigTest {
+
+    @Mock
+    private JobRepository jobRepository;
+    @Mock
+    private PlatformTransactionManager transactionManager;
+    @Mock
+    private S3Util s3Util;
+    @Mock
+    private StepContribution contribution;
+    @Mock
+    private ChunkContext chunkContext;
+
+    @TempDir
+    Path tempDir;
+
+    private LogBackupJobConfig config;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        config = new LogBackupJobConfig(jobRepository, transactionManager, s3Util);
+
+        setField(config, "backupBucket", "test-bucket");
+        setField(config, "logPrefix", "logs");
+        setField(config, "logDir", tempDir.toString());
+    }
+
+    private void setField(Object target, String field, Object value) {
+        try {
+            var f = target.getClass().getDeclaredField(field);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 백업대상_파일_없으면_정상종료() throws Exception {
+        RepeatStatus status = config.logBackupTasklet().execute(contribution, chunkContext);
+        assertEquals(RepeatStatus.FINISHED, status);
+        verifyNoInteractions(s3Util);
+    }
+
+    @Test
+    void main_로그_파일_업로드_정상동작() throws Exception {
+        String dateStr = LocalDate.now().minusDays(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        Path logFile = Files.createFile(tempDir.resolve("main-" + dateStr + ".log.gz"));
+        Files.writeString(logFile, "test log");
+
+        doNothing().when(s3Util)
+            .upload(anyString(), anyString(), any(InputStream.class), anyLong(), anyString());
+
+        RepeatStatus status = config.logBackupTasklet().execute(contribution, chunkContext);
+
+        assertEquals(RepeatStatus.FINISHED, status);
+        verify(s3Util, times(1)).upload(
+            eq("test-bucket"),
+            contains("/json/"),
+            any(InputStream.class),
+            anyLong(),
+            eq("application/gzip")
+        );
+    }
+
+    @Test
+    void debug_로그_파일_업로드_정상동작() throws Exception {
+        String dateStr = LocalDate.now().minusDays(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        Path logFile = Files.createFile(tempDir.resolve("debug-" + dateStr + ".log.gz"));
+        Files.writeString(logFile, "test log");
+
+        doNothing().when(s3Util)
+            .upload(anyString(), anyString(), any(InputStream.class), anyLong(), anyString());
+
+        RepeatStatus status = config.logBackupTasklet().execute(contribution, chunkContext);
+
+        assertEquals(RepeatStatus.FINISHED, status);
+        verify(s3Util, times(1)).upload(
+            eq("test-bucket"),
+            contains("/debug/"),
+            any(InputStream.class),
+            anyLong(),
+            eq("application/gzip")
+        );
+    }
+
+    @Test
+    void 파일_여러개_모두_업로드() throws Exception {
+        String dateStr = LocalDate.now().minusDays(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        Files.createFile(tempDir.resolve("main-" + dateStr + ".log.gz"));
+        Files.createFile(tempDir.resolve("debug-" + dateStr + ".log.gz"));
+
+        doNothing().when(s3Util)
+            .upload(anyString(), anyString(), any(InputStream.class), anyLong(), anyString());
+
+        RepeatStatus status = config.logBackupTasklet().execute(contribution, chunkContext);
+
+        assertEquals(RepeatStatus.FINISHED, status);
+        verify(s3Util, times(2)).upload(anyString(), anyString(), any(InputStream.class), anyLong(),
+            anyString());
+    }
+
+    @Test
+    void 디렉토리_읽기_실패시_예외발생() {
+        Path file = tempDir.resolve("notADir");
+        try {
+            Files.writeString(file, "not a dir");
+            setField(config, "logDir", file.toString());
+            assertThrows(RuntimeException.class,
+                () -> config.logBackupTasklet().execute(contribution, chunkContext));
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+}

--- a/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
@@ -1,0 +1,32 @@
+package com.sprint.mission.sb03monewteam1.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.launch.JobLauncher;
+
+@ExtendWith(MockitoExtension.class)
+class LogBackupSchedulerTest {
+
+    @Mock
+    private JobLauncher jobLauncher;
+
+    @Mock
+    private Job logBackupJob;
+
+    @InjectMocks
+    private LogBackupScheduler scheduler;
+
+    @Test
+    void 로그_백업_배치_작업이_실행되면_jobLauncher가_호출되어야_한다() throws Exception {
+        scheduler.runLogBackupJob();
+        then(jobLauncher).should(times(1)).run(any(), any());
+    }
+}

--- a/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
@@ -1,8 +1,10 @@
 package com.sprint.mission.sb03monewteam1.scheduler;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
 
 @ExtendWith(MockitoExtension.class)
@@ -21,11 +24,17 @@ class LogBackupSchedulerTest {
     @Mock
     private Job logBackupJob;
 
+    @Mock
+    private JobExplorer jobExplorer;
+
     @InjectMocks
     private LogBackupScheduler scheduler;
 
     @Test
     void 로그_백업_배치_작업이_실행되면_jobLauncher가_호출되어야_한다() throws Exception {
+        org.mockito.BDDMockito.given(jobExplorer.findRunningJobExecutions("logBackupJob"))
+            .willReturn(Collections.emptySet());
+
         scheduler.runLogBackupJob();
         then(jobLauncher).should(times(1)).run(any(), any());
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupSchedulerTest.java
@@ -1,11 +1,16 @@
 package com.sprint.mission.sb03monewteam1.scheduler;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willThrow;
 
 import java.util.Collections;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -37,5 +42,25 @@ class LogBackupSchedulerTest {
 
         scheduler.runLogBackupJob();
         then(jobLauncher).should(times(1)).run(any(), any());
+    }
+
+    @Test
+    void 이미_실행중이면_jobLauncher가_호출되지_않는다() throws Exception {
+        given(jobExplorer.findRunningJobExecutions("logBackupJob"))
+            .willReturn(
+                Collections.singleton(mock(org.springframework.batch.core.JobExecution.class)));
+
+        scheduler.runLogBackupJob();
+
+        verify(jobLauncher, never()).run(any(), any());
+    }
+
+    @Test
+    void jobLauncher_실행중_예외발생해도_예외_던지지_않는다() throws Exception {
+        given(jobExplorer.findRunningJobExecutions("logBackupJob"))
+            .willReturn(Collections.emptySet());
+        willThrow(new RuntimeException("실패")).given(jobLauncher).run(any(), any());
+
+        assertDoesNotThrow(() -> scheduler.runLogBackupJob());
     }
 }


### PR DESCRIPTION
### 📌 작업 개요
- 날짜 별 로그를 S3에 주기적으로 적재
- 전날 `main-*`, `debug-*`에 대한 로그 파일을 S3 경로에 백업합니다.

### ✅ 완료한 작업
- [x] 날짜 별 로그를 S3에 주기적으로 적재

### 🧪 테스트 결과
- 스케줄러 동작 확인
- S3 지정 경로에 파일 업로드 확인

### ⚠️ 기타 참고 사항
- 별도 작업에서 완료된 항목입니다.
  - 로그 환경 설정 완료.
  - aspect logging 테스트 완료
  - 일부 응답 헤더, MDC 로깅 설정 완료

### Related Issue

Closes #100 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그 파일을 AWS S3로 자동 백업하는 배치 작업이 추가되었습니다.
  * 로그 백업 배치 작업을 주기적으로 실행하는 스케줄러가 도입되었습니다.

* **설정**
  * 로그 백업을 위한 S3 경로 설정(`log-prefix`)이 추가되었습니다.
  * 기사 수집 스케줄이 시간 단위로 변경되었습니다.

* **테스트**
  * 로그 백업 스케줄러의 동작을 검증하는 단위 테스트가 추가되었습니다.
  * 로그 백업 배치 작업의 파일 업로드 동작과 예외 처리를 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->