### PR TITLE
[feat] [MN-72] refactor: 사용자 비밀번호 암호화 (단방향 해쉬)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'io.github.cdimascio:dotenv-java:3.0.2'
     testImplementation 'org.springframework.batch:spring-batch-test'
+
+    // Security
+    implementation 'org.springframework.security:spring-security-crypto'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.sprint.mission.sb03monewteam1.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/seeder/UserDataSeeder.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/seeder/UserDataSeeder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserDataSeeder implements DataSeeder {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final String DEFAULT_PASSWORD = "!qwe1234";
 
     @Override
     @Transactional
@@ -24,12 +28,15 @@ public class UserDataSeeder implements DataSeeder {
             log.info("UserDataSeeder: 사용자가 이미 존재하여 시드를 실행하지 않습니다.");
             return;
         }
+
+        String encodedPassword = passwordEncoder.encode(DEFAULT_PASSWORD);
+
         List<User> users = List.of(
-            createUser("user1@example.com", "유저1", "!qwe1234"),
-            createUser("user2@example.com", "유저2", "!qwe1234"),
-            createUser("user3@example.com", "유저3", "!qwe1234"),
-            createUser("user4@example.com", "유저4", "!qwe1234"),
-            createUser("user5@example.com", "유저5", "!qwe1234")
+            createUser("user1@example.com", "유저1", encodedPassword),
+            createUser("user2@example.com", "유저2", encodedPassword),
+            createUser("user3@example.com", "유저3", encodedPassword),
+            createUser("user4@example.com", "유저4", encodedPassword),
+            createUser("user5@example.com", "유저5", encodedPassword)
         );
 
         userRepository.saveAll(users);

--- a/src/test/java/com/sprint/mission/sb03monewteam1/fixture/UserFixture.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/fixture/UserFixture.java
@@ -139,4 +139,8 @@ public class UserFixture {
     public static UUID getDefaultId() {
         return DEFAULT_ID;
     }
+
+    public static String getDefaultPassword() {
+        return DEFAULT_PASSWORD;
+    }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/integration/UserIntegrationTest.java
@@ -38,7 +38,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,6 +75,9 @@ public class UserIntegrationTest {
 
     @Autowired
     private CommentRepository commentRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Test
     void 사용자_생성_시_Repository까지_반영되어야_한다() throws Exception {
@@ -123,7 +128,9 @@ public class UserIntegrationTest {
     void 정상적인_로그인_시_사용자_정보가_반환되어야_한다() throws Exception {
         // Given
         User user = UserFixture.createUser();
-        User savedUser = userRepository.save(user);
+        String encodedPassword = passwordEncoder.encode(UserFixture.getDefaultPassword());
+        ReflectionTestUtils.setField(user, "password", encodedPassword);
+        userRepository.save(user);
 
         UserLoginRequest userLoginRequest = UserFixture.createUserLoginRequest();
 
@@ -144,6 +151,7 @@ public class UserIntegrationTest {
             .nickname("testUser")
             .password("Password123!")
             .build();
+        ReflectionTestUtils.setField(user, "password", passwordEncoder.encode(user.getPassword()));
         userRepository.save(user);
 
         UserLoginRequest loginRequest = UserLoginRequest.builder()
@@ -166,6 +174,7 @@ public class UserIntegrationTest {
             .nickname("testUser")
             .password("correctPassword123!")
             .build();
+        ReflectionTestUtils.setField(user, "password", passwordEncoder.encode(user.getPassword()));
         userRepository.save(user);
 
         UserLoginRequest loginRequest = UserLoginRequest.builder()

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 테스트")
@@ -65,6 +66,9 @@ public class UserServiceTest {
 
     @Mock
     private CommentRepository commentRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Mock
     private UserMapper userMapper;
@@ -96,6 +100,7 @@ public class UserServiceTest {
             UserDto expectedUserDto = UserFixture.createUserDto();
 
             given(userRepository.existsByEmail(userRegisterRequest.email())).willReturn(false);
+            given(passwordEncoder.encode(userRegisterRequest.password())).willReturn("encodedPassword");
             given(userRepository.save(any(User.class))).willReturn(savedUser);
             given(userMapper.toDto(any(User.class))).willReturn(expectedUserDto);
 
@@ -145,6 +150,7 @@ public class UserServiceTest {
 
             given(userRepository.findByEmail(userLoginRequest.email())).willReturn(
                 Optional.of(existedUser));
+            given(passwordEncoder.matches(userLoginRequest.password(), existedUser.getPassword())).willReturn(true);
             given(userMapper.toDto(any(User.class))).willReturn(expectedUserDto);
 
             // When


### PR DESCRIPTION
### 📌 작업 개요
- 사용자 비밀번호 BCryptPasswordEncode를 사용해 단방향 해쉬 암호화

### ✅ 완료한 작업
- [x] 기존 평문 비밀번호 사용 로직을 인코딩 비밀번호를 사용하도록 리팩토링
- [x] 기존 테스트 코드 일부 수정

### 🧪 테스트 결과
- 로컬 테스트 완료
- 테스트 코드 통과 완료

### ⚠️ 기타 참고 사항
- 사용자는 db에 해쉬 함수를 거친 인코딩 password가 들어가기에, 일반적인 .equlas()말고 
Password.matches(비교할 평문 암호, db에 저장된 암호화된 암호) 형식으로 비교해야 함

### Related Issue

Closes #121 
