### PR TITLE
[feat] [MN-73] 사용자 활동 내역 조회 도메인 모델 업데이트

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewActivityBulkDeleteEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewActivityBulkDeleteEvent.java
@@ -1,0 +1,8 @@
+package com.sprint.mission.sb03monewteam1.event;
+
+import java.util.UUID;
+
+public record ArticleViewActivityBulkDeleteEvent(
+    UUID articleId
+) {
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountChangedEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountChangedEvent.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.sb03monewteam1.event;
+
+import java.util.UUID;
+
+public record ArticleViewCountChangedEvent(
+    UUID articleId,
+    long newViewCount
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountUpdateEvent.java
@@ -2,7 +2,7 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import java.util.UUID;
 
-public record ArticleViewCountChangedEvent(
+public record ArticleViewCountUpdateEvent(
     UUID articleId,
     long newViewCount
 ) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeCountUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeCountUpdateEvent.java
@@ -1,0 +1,10 @@
+package com.sprint.mission.sb03monewteam1.event;
+
+import java.util.UUID;
+
+public record CommentLikeCountUpdateEvent(
+    UUID commentId,
+    long newLikeCount
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityBulkDeleteEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityBulkDeleteEvent.java
@@ -2,8 +2,7 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import java.util.UUID;
 
-public record SubscriptionActivityDeleteEvent(
-    UUID userId,
+public record SubscriptionActivityBulkDeleteEvent(
     UUID interestId
 ) {
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityKeywordUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityKeywordUpdateEvent.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.UUID;
 
 public record SubscriptionActivityKeywordUpdateEvent(
+
     UUID interestId,
+
     List<String> newKeywords
 ) {
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityKeywordUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/SubscriptionActivityKeywordUpdateEvent.java
@@ -1,0 +1,11 @@
+package com.sprint.mission.sb03monewteam1.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record SubscriptionActivityKeywordUpdateEvent(
+    UUID interestId,
+    List<String> newKeywords
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/UserNameUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/UserNameUpdateEvent.java
@@ -1,0 +1,12 @@
+package com.sprint.mission.sb03monewteam1.event;
+
+import java.util.UUID;
+
+public record UserNameUpdateEvent(
+
+    UUID userId,
+
+    String newUserName
+) {
+
+}

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
@@ -1,14 +1,21 @@
 package com.sprint.mission.sb03monewteam1.event.listener;
 
+import com.mongodb.client.result.UpdateResult;
 import com.sprint.mission.sb03monewteam1.document.ArticleViewActivity;
 import com.sprint.mission.sb03monewteam1.dto.ArticleViewActivityDto;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountChangedEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.ArticleViewActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -21,6 +28,8 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
     ArticleViewActivityDto,
     ArticleViewActivity,
     ArticleViewActivityRepository> {
+
+    private final MongoTemplate mongoTemplate;
 
     private final ArticleViewActivityRepository repository;
 
@@ -50,7 +59,36 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateEvent(ArticleViewActivityCreateEvent event) {
-        log.debug("ArticleViewActivityCreateEvent 리스너 실행: {}", event);
+        log.debug("기사 뷰 활동 ArticleViewActivityCreateEvent 리스너 실행: {}", event);
         saveUserActivity(event.userId(), event.articleViewActivityDto());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBulkDeleteEvent(ArticleViewActivityBulkDeleteEvent event) {
+        UUID articleId = event.articleId();
+        log.debug("ArticleViewActivityBulkDeleteEvent 리스너 실행: articleId={}", articleId);
+
+        List<ArticleViewActivity> allDocs = repository.findAllByArticleViews_articleId(articleId);
+
+        for (ArticleViewActivity doc : allDocs) {
+            deleteUserActivity(doc.getUserId(), articleId);
+        }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleViewCountChanged(ArticleViewCountChangedEvent event) {
+        UUID articleId = event.articleId();
+        long newViewCount = event.newViewCount();
+
+        log.debug("ArticleViewCountChangedEvent 리스너 실행: articleId={}, newViewCount={}", articleId, newViewCount);
+
+        Query query = new Query(Criteria.where("articleViews.articleId").is(articleId));
+        Update update = new Update().set("articleViews.$.articleViewCount", newViewCount);
+
+        UpdateResult result = mongoTemplate.updateMulti(query, update, ArticleViewActivity.class);
+
+        log.info("기사 뷰 수 동기화 완료: articleId={}, 반영된 문서 수={}", articleId, result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
@@ -5,7 +5,7 @@ import com.sprint.mission.sb03monewteam1.document.ArticleViewActivity;
 import com.sprint.mission.sb03monewteam1.dto.ArticleViewActivityDto;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewCountChangedEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.ArticleViewActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +78,7 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleViewCountChanged(ArticleViewCountChangedEvent event) {
+    public void handleViewCountChanged(ArticleViewCountUpdateEvent event) {
         UUID articleId = event.articleId();
         long newViewCount = event.newViewCount();
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentActivityEventListener.java
@@ -87,7 +87,8 @@ public class CommentActivityEventListener extends AbstractActivityEventListener<
         UUID userId = event.userId();
         String newUserName = event.newUserName();
 
-        log.debug("UserNameUpdateEvent 리스너 실행 userId={}, newUserName={}", userId, newUserName);
+        log.debug("댓글 활동 UserNameUpdateEvent 리스너 실행 userId={}, newUserName={}", userId,
+            newUserName);
 
         Query query = new Query(Criteria.where("comments.userId").is(userId));
 
@@ -95,6 +96,7 @@ public class CommentActivityEventListener extends AbstractActivityEventListener<
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, CommentActivity.class);
 
-        log.info("UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId, result.getModifiedCount());
+        log.info("댓글 활동 UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId,
+            result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
@@ -86,7 +86,9 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
 
         Query query = new Query(Criteria.where("commentLikes.commentUserId").is(userId));
 
-        Update update = new Update().set("commentLikes.$.commentUserNickname", newUserName);
+        Update update = new Update()
+            .set("commentLikes.$[elem].commentUserNickname", newUserName)
+            .filterArray(Criteria.where("elem.commentUserId").is(userId));
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, CommentLikeActivity.class);
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
@@ -1,12 +1,14 @@
 package com.sprint.mission.sb03monewteam1.event.listener;
 
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
 import com.mongodb.client.result.UpdateResult;
 import com.sprint.mission.sb03monewteam1.document.CommentLikeActivity;
-import com.sprint.mission.sb03monewteam1.dto.CommentActivityDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeActivityDto;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.CommentLikeCountUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.CommentLikeActivityRepository;
 import java.util.ArrayList;
@@ -20,7 +22,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
@@ -59,7 +60,7 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
     }
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleCreateEvent(CommentLikeActivityCreateEvent event) {
         log.debug("CommentLikeActivityCreateEvent 리스너 실행: {}", event);
 
@@ -68,14 +69,14 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
 
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleDeleteEvent(CommentLikeActivityDeleteEvent event) {
         log.debug("CommentLikeActivityDeleteEvent 리스너 실행: {}", event);
         deleteUserActivity(event.userId(), event.commentId());
     }
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleUserNameUpdateForLikes(UserNameUpdateEvent event) {
         UUID userId = event.userId();
         String newUserName = event.newUserName();
@@ -100,7 +101,7 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
     }
 
     @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleCommentActivityUpdateForLikes(CommentActivityUpdateEvent event) {
         UUID commentId = event.commentId();
         String updatedContent = event.commentActivityDto().content();
@@ -122,5 +123,23 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
             log.info("댓글 좋아요 활동 CommentActivityUpdateEvent 리스너 실행 완료 commentId={}, 수정된 문서 수={}",
                 commentId, result.getModifiedCount());
         }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleLikeCountChanged(CommentLikeCountUpdateEvent event) {
+        UUID commentId = event.commentId();
+        long newLikeCount = event.newLikeCount();
+
+        log.debug("CommentLikeCountChangedEvent 리스너 실행: commentId={}, newLikeCount={}", commentId,
+            newLikeCount);
+
+        Query query = new Query(Criteria.where("commentLikes.commentId").is(commentId));
+        Update update = new Update().set("commentLikes.$.commentLikeCount", newLikeCount);
+
+        UpdateResult result = mongoTemplate.updateMulti(query, update, CommentLikeActivity.class);
+
+        log.info("댓글 좋아요 활동 CommentLikeCountChangedEvent 리스너 실행 완료: commentId={}, 수정 문서 수={}", commentId,
+            result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
@@ -73,11 +73,11 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleKeywordUpdate(SubscriptionActivityKeywordUpdateEvent event) {
+    public void handleKeywordUpdateEvent(SubscriptionActivityKeywordUpdateEvent event) {
         UUID interestId = event.interestId();
         List<String> keywords = event.newKeywords();
 
-        log.debug("[이벤트 수신] interestId={}, newKeywords={}", interestId, keywords);
+        log.debug("handleKeywordUpdateEvent 리스너 실행: interestId={}, newKeywords={}", interestId, keywords);
 
         Query query = new Query(Criteria.where("subscriptions.interestId").is(interestId));
         log.debug("[쿼리 생성] query={}", query);
@@ -89,7 +89,7 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
         log.debug("[문서 검색] 조건에 맞는 문서 수={}", matchedDocs.size());
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, SubscriptionActivity.class);
-        log.info("[업데이트 실행] interestId={}, 수정 문서 수={}", interestId, result.getModifiedCount());
+        log.info("handleKeywordUpdateEvent 리스너 실행 완료: interestId={}, 수정 문서 수={}", interestId, result.getModifiedCount());
     }
 
     @Async

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
@@ -1,16 +1,22 @@
 package com.sprint.mission.sb03monewteam1.event.listener;
 
+import com.mongodb.client.result.UpdateResult;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import com.sprint.mission.sb03monewteam1.document.SubscriptionActivity;
 import com.sprint.mission.sb03monewteam1.dto.SubscriptionDto;
-import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityKeywordUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.SubscriptionActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -23,6 +29,8 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
     SubscriptionDto,
     SubscriptionActivity,
     SubscriptionActivityRepository> {
+
+    private final MongoTemplate mongoTemplate;
 
     private final SubscriptionActivityRepository repository;
 
@@ -51,7 +59,7 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(SubscriptionActivityCreateEvent event) {
+    public void handleCreateEvent(SubscriptionActivityCreateEvent event) {
         log.debug("SubscriptionActivityCreateEvent 리스너 실행: {}", event);
         saveUserActivity(event.userId(), event.subscriptionDto());
     }
@@ -61,5 +69,39 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
     public void handleDeleteEvent(SubscriptionActivityDeleteEvent event) {
         log.debug("SubscriptionActivityDeleteEvent 리스너 실행: {}", event);
         deleteUserActivity(event.userId(), event.interestId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleKeywordUpdate(SubscriptionActivityKeywordUpdateEvent event) {
+        UUID interestId = event.interestId();
+        List<String> keywords = event.newKeywords();
+
+        log.debug("[이벤트 수신] interestId={}, newKeywords={}", interestId, keywords);
+
+        Query query = new Query(Criteria.where("subscriptions.interestId").is(interestId));
+        log.debug("[쿼리 생성] query={}", query);
+
+        Update update = new Update().set("subscriptions.$.interestKeywords", keywords);
+        log.debug("[업데이트 정의] update={}", update.getUpdateObject());
+
+        List<SubscriptionActivity> matchedDocs = mongoTemplate.find(query, SubscriptionActivity.class);
+        log.debug("[문서 검색] 조건에 맞는 문서 수={}", matchedDocs.size());
+
+        UpdateResult result = mongoTemplate.updateMulti(query, update, SubscriptionActivity.class);
+        log.info("[업데이트 실행] interestId={}, 수정 문서 수={}", interestId, result.getModifiedCount());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBulkDeleteEvent(SubscriptionActivityBulkDeleteEvent event) {
+        UUID interestId = event.interestId();
+        log.debug("SubscriptionActivityBulkDeleteEvent 리스너 실행: interestId={}", interestId);
+
+        List<SubscriptionActivity> allDocs = repository.findAllBySubscriptions_interestId(
+            interestId);
+        for (SubscriptionActivity doc : allDocs) {
+            deleteUserActivity(doc.getUserId(), interestId);
+        }
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/ArticleViewActivityRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/ArticleViewActivityRepository.java
@@ -3,7 +3,6 @@ package com.sprint.mission.sb03monewteam1.repository.mongodb;
 import com.sprint.mission.sb03monewteam1.document.ArticleViewActivity;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
@@ -14,5 +13,4 @@ public interface ArticleViewActivityRepository extends MongoRepository<ArticleVi
         "{ $project: { articleViews: { $slice: [ { $sortArray: { input: \"$articleViews\", sortBy: { createdAt: -1 } } }, 10 ] } } }"
     })
     Optional<ArticleViewActivity> findRecent10ArticleViewsByUserId(UUID userId);
-
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/ArticleViewActivityRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/ArticleViewActivityRepository.java
@@ -1,6 +1,7 @@
 package com.sprint.mission.sb03monewteam1.repository.mongodb;
 
 import com.sprint.mission.sb03monewteam1.document.ArticleViewActivity;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.mongodb.repository.Aggregation;
@@ -13,4 +14,6 @@ public interface ArticleViewActivityRepository extends MongoRepository<ArticleVi
         "{ $project: { articleViews: { $slice: [ { $sortArray: { input: \"$articleViews\", sortBy: { createdAt: -1 } } }, 10 ] } } }"
     })
     Optional<ArticleViewActivity> findRecent10ArticleViewsByUserId(UUID userId);
+
+    List<ArticleViewActivity> findAllByArticleViews_articleId(UUID articleId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/CommentActivityRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/CommentActivityRepository.java
@@ -3,7 +3,6 @@ package com.sprint.mission.sb03monewteam1.repository.mongodb;
 import com.sprint.mission.sb03monewteam1.document.CommentActivity;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/CommentLikeActivityRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/CommentLikeActivityRepository.java
@@ -3,7 +3,6 @@ package com.sprint.mission.sb03monewteam1.repository.mongodb;
 import com.sprint.mission.sb03monewteam1.document.CommentLikeActivity;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.MongoRepository;
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/SubscriptionActivityRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/mongodb/SubscriptionActivityRepository.java
@@ -1,9 +1,11 @@
 package com.sprint.mission.sb03monewteam1.repository.mongodb;
 
 import com.sprint.mission.sb03monewteam1.document.SubscriptionActivity;
+import java.util.List;
 import java.util.UUID;
-import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface SubscriptionActivityRepository extends MongoRepository<SubscriptionActivity, UUID> {
+
+    List<SubscriptionActivity> findAllBySubscriptions_interestId(UUID interestId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -16,13 +16,10 @@ import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.ArticleInterest;
 import com.sprint.mission.sb03monewteam1.entity.ArticleView;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
-import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewCountChangedEvent;
-import com.sprint.mission.sb03monewteam1.event.CommentActivityUpdateEvent;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.NewArticleCollectEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
@@ -113,8 +110,8 @@ public class ArticleServiceImpl implements ArticleService {
         ArticleView articleView = ArticleView.createArticleView(userId, article);
         ArticleView savedArticleView = articleViewRepository.save(articleView);
 
-        ArticleViewCountChangedEvent event =
-            new ArticleViewCountChangedEvent(article.getId(), article.getViewCount());
+        ArticleViewCountUpdateEvent event =
+            new ArticleViewCountUpdateEvent(article.getId(), article.getViewCount());
 
         eventPublisher.publishEvent(event);
         log.debug("기사 뷰 활동 내역 동기화 이벤트 발행 완료: {}", event);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -9,9 +9,10 @@ import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
-import com.sprint.mission.sb03monewteam1.event.CommentActivityDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityDeleteEvent;
+import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityKeywordUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
@@ -219,6 +220,11 @@ public class InterestServiceImpl implements InterestService {
 
         log.info("관심사 수정 완료: response={}", updatedInterestDto);
 
+        eventPublisher.publishEvent(
+            new SubscriptionActivityKeywordUpdateEvent(interestId, newKeywords)
+        );
+        log.info("SubscriptionActivityKeywordUpdateEvent 발행 완료: interestId={}", interestId);
+
         return updatedInterestDto;
     }
 
@@ -236,6 +242,12 @@ public class InterestServiceImpl implements InterestService {
         interestRepository.delete(interest);
 
         log.info("관심사 삭제 완료: interestId={}", interestId);
+
+        SubscriptionActivityBulkDeleteEvent event = new SubscriptionActivityBulkDeleteEvent(
+            interestId);
+        eventPublisher.publishEvent(event);
+
+        log.debug("삭제된 관심사 구독 활동 내역 삭제 이벤트 발행 완료: {}", event);
     }
 
     @Override
@@ -258,7 +270,8 @@ public class InterestServiceImpl implements InterestService {
         log.info("구독 취소 완료: subscriptionId={}, userId={}, interestId={}, 남은 구독자 수={}",
             subscription.getId(), userId, interestId, interest.getSubscriberCount());
 
-        SubscriptionActivityDeleteEvent event = new SubscriptionActivityDeleteEvent(userId, interestId);
+        SubscriptionActivityDeleteEvent event = new SubscriptionActivityDeleteEvent(userId,
+            interestId);
         eventPublisher.publishEvent(event);
 
         log.debug("구독 활동 내역 삭제 이벤트 발행 완료: {}", event);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/InterestServiceImpl.java
@@ -9,7 +9,9 @@ import com.sprint.mission.sb03monewteam1.entity.Interest;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.event.CommentActivityDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityCreateEvent;
+import com.sprint.mission.sb03monewteam1.event.SubscriptionActivityDeleteEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
@@ -255,6 +257,11 @@ public class InterestServiceImpl implements InterestService {
 
         log.info("구독 취소 완료: subscriptionId={}, userId={}, interestId={}, 남은 구독자 수={}",
             subscription.getId(), userId, interestId, interest.getSubscriberCount());
+
+        SubscriptionActivityDeleteEvent event = new SubscriptionActivityDeleteEvent(userId, interestId);
+        eventPublisher.publishEvent(event);
+
+        log.debug("구독 활동 내역 삭제 이벤트 발행 완료: {}", event);
     }
 
     private String calculateNextCursor(List<Interest> interests, String orderBy, int limit) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;
 import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
 import com.sprint.mission.sb03monewteam1.exception.user.InvalidEmailOrPasswordException;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ public class UserServiceImpl implements UserService {
     private final CommentLikeRepository commentLikeRepository;
     private final CommentRepository commentRepository;
     private final UserMapper userMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public UserDto create(UserRegisterRequest userRegisterRequest) {
@@ -108,6 +111,9 @@ public class UserServiceImpl implements UserService {
         user.update(request.nickname());
 
         log.info("사용자 정보 수정 완료 - id={}, nickname={}", user.getId(), user.getNickname());
+
+        eventPublisher.publishEvent(new UserNameUpdateEvent(userId, request.nickname()));
+        log.debug("UserNameUpdateEvent 발행 완료: userId={}, newUserName={}", userId, request.nickname());
 
         return userMapper.toDto(user);
     }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -18,7 +18,6 @@ import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.User;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.sprint.mission.sb03monewteam1.dto.UserDto;
 import com.sprint.mission.sb03monewteam1.dto.request.UserLoginRequest;
@@ -18,6 +19,8 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
+import com.sprint.mission.sb03monewteam1.event.CommentActivityCreateEvent;
+import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;
 import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
@@ -46,6 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("UserService 테스트")
@@ -71,6 +75,9 @@ public class UserServiceTest {
 
     @InjectMocks
     private UserServiceImpl userService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @BeforeEach
     @DisplayName("테스트 환경 설정 확인")
@@ -268,6 +275,8 @@ public class UserServiceTest {
 
             then(userRepository).should().findByIdAndIsDeletedFalse(userId);
             then(userMapper).should().toDto(existedUser);
+
+            verify(eventPublisher).publishEvent(any(UserNameUpdateEvent.class));
         }
 
         @Test

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -20,7 +20,6 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
-import com.sprint.mission.sb03monewteam1.event.CommentActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;


### PR DESCRIPTION
### 📌 작업 개요
- 각 도메인 별 사용자 활동 발생 시 연관 도메인 모델 업데이트 구현

### ✅ 완료한 작업
- [x] 기존 구현된 기능 외 관심사 뷰, 사용자 이름 수정 등 복수 모델에 영향 가는 사용자 활동에 대한 모델 업데이트 처리

### 🧪 테스트 결과
- 로컬 테스트 완료

### ⚠️ 기타 참고 사항
- 로깅과 네이밍 등 코드 스타일이 통일되지 않은 부분이 다수 있어 리팩토링 예정

### Related Issue

Closes #120 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 기사, 댓글, 구독, 사용자 활동에 대한 다양한 이벤트 동기화 및 일괄 삭제 기능이 추가되었습니다.
  * 기사 조회수, 댓글 좋아요 수, 구독 키워드, 사용자 닉네임 변경 등 주요 활동 변화가 실시간으로 반영됩니다.
  * MongoDB 다중 문서 및 배열 요소 업데이트를 통한 활동 정보 동기화가 강화되었습니다.

* **버그 수정**
  * 없음

* **테스트**
  * 사용자 닉네임 변경 시 이벤트 발행 여부에 대한 테스트가 추가되었습니다.

* **기타**
  * 일부 불필요한 import가 제거되고, 코드 가독성을 위한 소규모 정리가 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->