### PR TITLE
[test] [MN-74] 댓글 관리_테스트 케이스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, exclude: [
+                            "**/*ActivityEventListener.class",
+                            "**/Q*.class",
                             '**/seeder/**',
                             '**/config/**'
                     ])

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -1,9 +1,9 @@
 package com.sprint.mission.sb03monewteam1.service;
 
+import com.sprint.mission.sb03monewteam1.dto.CommentActivityDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeActivityDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
-import com.sprint.mission.sb03monewteam1.dto.CommentActivityDto;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -32,8 +32,8 @@ import com.sprint.mission.sb03monewteam1.mapper.CommentLikeActivityMapper;
 import com.sprint.mission.sb03monewteam1.mapper.CommentLikeMapper;
 import com.sprint.mission.sb03monewteam1.mapper.CommentMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.article.ArticleRepository;
-import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepository;
+import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -135,11 +135,7 @@ public class CommentServiceImpl implements CommentService {
             switch (orderField) {
                 case "createdAt" -> parseInstant(cursor);
                 case "likeCount" -> parseLong(cursor);
-                default ->
-                    throw new InvalidSortOptionException(ErrorCode.INVALID_SORT_FIELD, "sortBy",
-                        orderField);
             }
-            ;
         }
 
         List<Comment> comments = commentRepository.findCommentsWithCursorBySort(

--- a/src/test/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/repository/CommentRepositoryTest.java
@@ -243,9 +243,6 @@ public class CommentRepositoryTest {
         );
 
         // then
-        result.forEach(c ->
-            System.out.printf("likeCount: %d, createdAt: %s%n", c.getLikeCount(), c.getCreatedAt()));
-
         assertThat(result).allSatisfy(comment -> {
             boolean valid =
                 comment.getLikeCount() > 2 ||

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -24,7 +24,6 @@ import com.sprint.mission.sb03monewteam1.event.CommentActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
-import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentAlreadyLikedException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentException;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentLikeNotFoundException;

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -39,8 +39,8 @@ import com.sprint.mission.sb03monewteam1.mapper.CommentLikeActivityMapper;
 import com.sprint.mission.sb03monewteam1.mapper.CommentLikeMapper;
 import com.sprint.mission.sb03monewteam1.mapper.CommentMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.article.ArticleRepository;
-import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepository;
+import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -295,7 +295,7 @@ public class CommentServiceTest {
         }
 
         @Test
-        void 커서기반으로_다음페이지를_정상조회한다() {
+        void 커서기반으로_다음페이지를_정상조회한다_생성일_기준() {
 
             // given
             UUID articleId = UUID.randomUUID();
@@ -318,6 +318,65 @@ public class CommentServiceTest {
 
             Comment lastOfFirstPage = firstPage.get(pageSize - 1);
             Instant cursor = lastOfFirstPage.getCreatedAt();
+            Instant after = lastOfFirstPage.getCreatedAt();
+
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
+            given(commentRepository.findCommentsWithCursorBySort(
+                eq(articleId), eq(cursor.toString()), eq(after), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
+                .willReturn(secondPage);
+            given(commentRepository.countByArticleIdAndIsDeletedFalse(article.getId())).willReturn(10L);
+            given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
+                    Comment comment = invocation.getArgument(0);
+                    return CommentFixture.createCommentDto(comment);
+                }
+            );
+
+            // when
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
+                articleId, cursor.toString(), after, pageSize, sortBy, sortDirection, userId
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).hasSize(5);
+
+            List<String> expectedContents = secondPage.stream()
+                .map(Comment::getContent)
+                .toList();
+
+            List<String> actualContents = result.content().stream()
+                .map(CommentDto::content)
+                .toList();
+
+            assertThat(actualContents).isEqualTo(expectedContents);
+            assertThat(result.totalElements()).isEqualTo(10L);
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        void 커서기반으로_다음페이지를_정상조회한다_좋아요수_기준() {
+
+            // given
+            UUID articleId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
+            int pageSize = 5;
+            String sortBy = "likeCount";
+            String sortDirection = "DESC";
+
+            List<Comment> commentList = createCommentsWithLikeCount(10, article, user);
+
+            List<Comment> sorted = commentList.stream()
+                .sorted(Comparator.comparing(Comment::getLikeCount).reversed())
+                .collect(Collectors.toList());
+
+            List<Comment> firstPage = sorted.subList(0, pageSize + 1);
+            List<Comment> secondPage = sorted.subList(pageSize, sorted.size());
+
+            Comment lastOfFirstPage = firstPage.get(pageSize - 1);
+            Long cursor = lastOfFirstPage.getLikeCount();
             Instant after = lastOfFirstPage.getCreatedAt();
 
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
@@ -482,7 +541,7 @@ public class CommentServiceTest {
         }
 
         @Test
-        void 유효하지_않은_커서로_조회시_예외가_발생한다() {
+        void 유효하지_않은_커서로_조회시_예외가_발생한다_생성일_기준() {
 
             // given
             UUID articleId = UUID.randomUUID();
@@ -504,6 +563,31 @@ public class CommentServiceTest {
                 commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection, userId)
             ).isInstanceOf(InvalidCursorException.class)
                 .hasMessageContaining(ErrorCode.INVALID_CURSOR_DATE.getMessage());
+        }
+
+        @Test
+        void 유효하지_않은_커서로_조회시_예외가_발생한다_좋아요수_기준() {
+
+            // given
+            UUID articleId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID userId = UUID.randomUUID();
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
+            String invalidCursor = "invalid-value";
+            int pageSize = 5;
+            String sortBy = "likeCount";
+            String sortDirection = "DESC";
+
+            List<Comment> comments = createCommentsWithLikeCount(pageSize, article, user);
+
+            given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
+
+            // when & then
+            assertThatThrownBy(() ->
+                commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection, userId)
+            ).isInstanceOf(InvalidCursorException.class)
+                .hasMessageContaining(ErrorCode.INVALID_CURSOR_COUNT.getMessage());
         }
 
         @Test
@@ -566,6 +650,66 @@ public class CommentServiceTest {
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_DIRECTION.getMessage());
+        }
+
+        @Test
+        void articleId가_null인_경우_삭제되지_않은_전체_댓글수를_반환한다() {
+
+            // given
+            UUID articleId = UUID.randomUUID();
+            Article article = ArticleFixture.createArticleWithId(articleId);
+            UUID articleId2 = UUID.randomUUID();
+            Article article2 = ArticleFixture.createArticleWithId(articleId2);
+            UUID userId = UUID.randomUUID();
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", userId);
+
+            int pageSize = 5;
+            String sortBy = "createdAt";
+            String sortDirection = "DESC";
+
+            List<Comment> commentList = createCommentsWithCreatedAt(5, article, user);
+            commentList.addAll(createCommentsWithCreatedAt(5, article2, user));
+
+            List<Comment> sorted = commentList.stream()
+                .sorted(Comparator.comparing(Comment::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+            List<Comment> firstPage = sorted.subList(0, pageSize + 1);
+
+            given(commentRepository.findCommentsWithCursorBySort(
+                eq(null), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
+                .willReturn(firstPage);
+            given(commentRepository.countByIsDeletedFalse()).willReturn(10L);
+            given(commentMapper.toDto(any(Comment.class))).willAnswer(invocation -> {
+                    Comment comment = invocation.getArgument(0);
+                    return CommentFixture.createCommentDto(comment);
+                }
+            );
+
+            // when
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
+                null, null, null, pageSize, sortBy, sortDirection, userId
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.content()).hasSize(pageSize);
+
+            List<String> expectedContents = sorted.subList(0, pageSize).stream()
+                .map(Comment::getContent)
+                .toList();
+
+            List<String> actualContents = result.content().stream()
+                .map(CommentDto::content)
+                .toList();
+
+            assertThat(actualContents).isEqualTo(expectedContents);
+            assertThat(result.nextCursor()).isEqualTo(sorted.get(pageSize).getCreatedAt().toString());
+            assertThat(result.nextAfter()).isEqualTo(sorted.get(pageSize).getCreatedAt());
+            assertThat(result.size()).isEqualTo(pageSize);
+            assertThat(result.totalElements()).isEqualTo(10L);
+            assertThat(result.hasNext()).isTrue();
         }
     }
 
@@ -655,6 +799,35 @@ public class CommentServiceTest {
                 commentService.update(commentId, otherUserId, commentUpdateRequest
                 )).isInstanceOf(UnauthorizedCommentAccessException.class)
                 .hasMessageContaining(ErrorCode.FORBIDDEN_ACCESS.getMessage());
+        }
+
+        @Test
+        void 댓글DTO가_null이면_예외가_발생한다() {
+
+            // given
+            User user = UserFixture.createUser();
+            ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+            UUID userId = user.getId();
+            Article article = ArticleFixture.createArticleWithId(UUID.randomUUID());
+            String originalContent = "기존 댓글";
+            String updateContent = "댓글 수정 테스트";
+            Comment comment = CommentFixture.createComment(originalContent, user, article);
+            ReflectionTestUtils.setField(comment, "id", UUID.randomUUID());
+            UUID commentId = comment.getId();
+
+            CommentUpdateRequest commentUpdateRequest = CommentUpdateRequest.builder()
+                .content(updateContent)
+                .build();
+
+            given(commentRepository.findByIdAndIsDeletedFalse(commentId)).willReturn(Optional.of(comment));
+            given(commentMapper.toDto(any(Comment.class))).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() ->
+                commentService.update(commentId, userId, commentUpdateRequest)
+            )
+                .isInstanceOf(CommentException.class)
+                .hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
         }
     }
 


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 관리 관련 테스트 케이스 추가 (Repository, Service)

### ✅ 완료한 작업
- [x] 레포지토리/서비스 테스트 케이스 추가

### 🧪 테스트 결과
- 모든 테스트 코드 통과

### ⚠️ 기타 참고 사항
- 아직 남은 작업이나, 리뷰어가 확인해야 할 이슈

### Related Issue

Closes #124 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 댓글 목록 조회 및 정렬, 커서 기반 페이지네이션, 예외 처리에 대한 다양한 테스트 케이스가 추가 및 개선되었습니다.
  * 잘못된 정렬 기준 입력 시 예외 발생 여부를 검증하는 테스트가 추가되었습니다.
  * 댓글 수정 시 DTO가 null인 경우 예외 발생을 확인하는 테스트가 추가되었습니다.
  * 전체 댓글 수 반환, 커서·정렬 기준별 페이지네이션 등 다양한 상황에 대한 테스트가 보강되었습니다.
  * 좋아요 수 및 생성일 기준 커서 기반 정렬과 페이지네이션에 대한 상세 테스트가 추가되었으며, nextAfter 파라미터 활용에 대한 검증이 포함되었습니다.
  * 존재하지 않는 기사 댓글 조회 시 예외 처리 테스트가 추가되었습니다.
  * 정렬 기준과 방향이 null일 경우 기본값으로 설정되는 동작에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->