### PR TITLE
[feat] [MN-76] 뉴스 기사 추가 작업

### DIFF
--- a/grafana/provisioning/dashboards/json/New dashboard-1753252745228.json
+++ b/grafana/provisioning/dashboards/json/New dashboard-1753252745228.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 3,
   "links": [],
   "panels": [
     {
@@ -74,29 +74,12 @@
         {
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "monew_batch_job_success_total{exported_job=\"naverNewsCollectJob\"}",
+          "expr": "monew_batch_job_success_total{exported_job=\"newsCollectJob\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "{{exported_job}}",
           "range": true,
           "refId": "A",
-          "useBackend": false
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "feseujtetqb5sd"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "monew_batch_job_success_total{exported_job=\"naverNewsCollectJob\"}",
-          "fullMetaSearch": false,
-          "hide": false,
-          "includeNullMetadata": true,
-          "instant": false,
-          "legendFormat": "{{exported_job}}",
-          "range": true,
-          "refId": "B",
           "useBackend": false
         }
       ],
@@ -307,7 +290,7 @@
           "useBackend": false
         }
       ],
-      "title": "New panel",
+      "title": "관심사별 기사 개수",
       "type": "table"
     },
     {
@@ -459,5 +442,5 @@
   "timezone": "browser",
   "title": "New dashboard",
   "uid": "911196ba-c1cc-4cf7-85de-62ed51a8855f",
-  "version": 5
+  "version": 1
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobConfig.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobConfig.java
@@ -99,7 +99,7 @@ public class ArticleBackupJobConfig {
     public ItemWriter<ArticleDto> writer() {
         return articles -> {
             Timer.Sample sample = Timer.start(monewMetrics.getMeterRegistry());
-            String dateStr = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(0)
+            String dateStr = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
             String key = String.format("%s/backup-articles-%s.json", backupPrefix, dateStr);
             try {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobConfig.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobConfig.java
@@ -10,11 +10,17 @@ import io.micrometer.core.instrument.Timer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -40,17 +46,17 @@ public class ArticleBackupJobConfig {
     @Value("${aws.s3.bucket:}")
     private String backupBucket;
 
-    @Value("${aws.s3.backup-prefix:articles/}")
+    @Value("${aws.s3.backup-prefix:articles}")
     private String backupPrefix;
 
     @Bean
-    public org.springframework.batch.core.JobExecutionListener articleBackupJobExecutionListener() {
+    public JobExecutionListener articleBackupJobExecutionListener() {
         return new JobCompletionMetricsListener("articleBackupJob", monewMetrics);
     }
 
     @Bean
     public Job articleBackupJob(JobRepository jobRepository, Step articleBackupStep,
-        org.springframework.batch.core.JobExecutionListener articleBackupJobExecutionListener) {
+        JobExecutionListener articleBackupJobExecutionListener) {
         return new JobBuilder("articleBackupJob", jobRepository)
             .start(articleBackupStep)
             .listener(articleBackupJobExecutionListener)
@@ -66,10 +72,19 @@ public class ArticleBackupJobConfig {
             .reader(reader())
             .processor(processor())
             .writer(writer())
+            .listener(new StepExecutionListener() {
+                @Override
+                public ExitStatus afterStep(StepExecution stepExecution) {
+                    long count = stepExecution.getWriteCount();
+                    log.info("기사 백업 전체 완료 - 전체 백업된 기사 개수: {}", count);
+                    return ExitStatus.COMPLETED;
+                }
+            })
             .build();
     }
 
     @Bean
+    @StepScope
     public ItemReader<ArticleDto> reader() {
         List<ArticleDto> articles = articleRepositoryCustom.findAllCreatedYesterday();
         return new IteratorItemReader<>(articles);
@@ -84,10 +99,10 @@ public class ArticleBackupJobConfig {
     public ItemWriter<ArticleDto> writer() {
         return articles -> {
             Timer.Sample sample = Timer.start(monewMetrics.getMeterRegistry());
-            String key = backupPrefix + "backup-articles-" +
-                LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1) + ".json";
+            String dateStr = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(0)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            String key = String.format("%s/backup-articles-%s.json", backupPrefix, dateStr);
             try {
-                log.info("백업 파일 업로드 시작: key={}", key);
                 String json = objectMapper.writeValueAsString(articles);
                 byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8);
 
@@ -98,8 +113,6 @@ public class ArticleBackupJobConfig {
                     jsonBytes.length,
                     "application/json"
                 );
-
-                log.info("백업 파일 업로드 완료: key={}", key);
             } catch (Exception e) {
                 log.error("백업 파일 업로드 중 오류 발생", e);
                 throw new RuntimeException(e);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfig.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfig.java
@@ -1,16 +1,15 @@
 package com.sprint.mission.sb03monewteam1.batch.job;
 
-import com.sprint.mission.sb03monewteam1.util.S3Util;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -22,6 +21,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+
+import com.sprint.mission.sb03monewteam1.util.S3Util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
@@ -38,7 +42,7 @@ public class LogBackupJobConfig {
     @Value("${aws.s3.log-prefix:logs}")
     private String logPrefix;
 
-    @Value("${logDir:logs}")
+    @Value("${aws.s3.logDir:/app/logs}")
     private String logDir;
 
     @Bean
@@ -65,28 +69,29 @@ public class LogBackupJobConfig {
                 log.warn("로그 디렉토리가 존재하지 않습니다: {}", logDir);
                 return RepeatStatus.FINISHED;
             }
+            List<Path> fileList;
             try (Stream<Path> files = Files.list(logPath)) {
-                files.filter(Files::isRegularFile)
-                    .filter(path -> {
-                        String name = path.getFileName().toString();
-                        return (name.startsWith("main-" + dateStr) || name.startsWith(
-                            "debug-" + dateStr))
-                            && name.endsWith(".log.gz");
-                    })
-                    .forEach(path -> uploadFile(targetDate, path));
-            } catch (IOException e) {
-                log.error("로그 디렉토리 읽기 실패: {}", logDir, e);
-                throw new RuntimeException("로그 백업 실패", e);
+                fileList = files.filter(Files::isRegularFile)
+                    .collect(Collectors.toList());
+            } catch (Exception e) {
+                throw new RuntimeException("로그 디렉토리 읽기 실패: " + logDir, e);
             }
+            long count = fileList.stream()
+                .filter(path -> {
+                    String name = path.getFileName().toString();
+                    return name.matches("(main|debug)-" + dateStr + "(-\\d+)?\\.log\\.gz");
+                })
+                .peek(path -> uploadFile(targetDate, path))
+                .count();
+            log.info("로그 백업 완료 - 백업된 파일 개수: {}", count);
             return RepeatStatus.FINISHED;
         };
     }
 
     private void uploadFile(LocalDate date, Path path) {
-        String subDir = path.getFileName().toString().startsWith("main-") ? "json" : "debug";
-        String key = String.format("%s/%s/%s/%s", logPrefix, subDir,
-            date.format(DateTimeFormatter.ofPattern("yyyy/MM/dd")),
-            path.getFileName());
+        String subDir = path.getFileName().toString().startsWith("main-") ? "main" : "debug";
+        String dateStr = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String key = String.format("%s/%s/%s/%s", logPrefix, subDir, dateStr, path.getFileName());
         try (InputStream is = Files.newInputStream(path)) {
             s3Util.upload(backupBucket, key, is, Files.size(path), "application/gzip");
             log.info("로그 백업 성공: {} -> {}", path, key);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/ArticleController.java
@@ -1,15 +1,9 @@
 package com.sprint.mission.sb03monewteam1.controller;
 
-import com.sprint.mission.sb03monewteam1.controller.api.ArticleApi;
-import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
-import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
-import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
-import com.sprint.mission.sb03monewteam1.service.ArticleService;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,6 +13,16 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.sprint.mission.sb03monewteam1.controller.api.ArticleApi;
+import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
+import com.sprint.mission.sb03monewteam1.dto.ArticleRestoreResultDto;
+import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
+import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
+import com.sprint.mission.sb03monewteam1.service.ArticleService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
@@ -82,5 +86,15 @@ public class ArticleController implements ArticleApi {
         log.info("기사 물리 삭제 요청 - articleId: {}", articleId);
         articleService.deleteHard(articleId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    @GetMapping("/restore")
+    public ResponseEntity<List<ArticleRestoreResultDto>> restoreArticles(
+        @RequestParam String from,
+        @RequestParam String to
+    ) {
+        List<ArticleRestoreResultDto> result = articleService.restoreArticles(from, to);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/ArticleApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/ArticleApi.java
@@ -1,24 +1,28 @@
 package com.sprint.mission.sb03monewteam1.controller.api;
 
 
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
 import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
+import com.sprint.mission.sb03monewteam1.dto.ArticleRestoreResultDto;
 import com.sprint.mission.sb03monewteam1.dto.ArticleViewDto;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.exception.ErrorResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.time.Instant;
-import java.util.List;
-import java.util.UUID;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "기사 관리", description = "기사 조회 및 뷰 관리 API")
 public interface ArticleApi {
@@ -75,4 +79,15 @@ public interface ArticleApi {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<Void> deleteHard(@PathVariable UUID articleId);
+
+    @Operation(summary = "뉴스 복구", description = "유실된 뉴스 기사를 복구.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "복구 성공", content = @Content(schema = @Schema(implementation = ArticleRestoreResultDto.class))),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/restore")
+    ResponseEntity<List<ArticleRestoreResultDto>> restoreArticles(
+        @RequestParam String from,
+        @RequestParam String to
+    );
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/Article.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/Article.java
@@ -1,26 +1,26 @@
 package com.sprint.mission.sb03monewteam1.entity;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import com.sprint.mission.sb03monewteam1.entity.base.BaseEntity;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Entity
 @Table(name = "articles")
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Article extends BaseEntity {
 
@@ -40,16 +40,20 @@ public class Article extends BaseEntity {
     private String summary;
 
     @Column(name = "comment_count", nullable = false)
-    private Long commentCount;
+    @Builder.Default
+    private Long commentCount = 0L;
 
     @Column(name = "view_count", nullable = false)
-    private Long viewCount;
+    @Builder.Default
+    private Long viewCount = 0L;
 
     @Column(name = "is_deleted", nullable = false)
-    private Boolean isDeleted;
+    @Builder.Default
+    private Boolean isDeleted = false;
 
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<ArticleView> articleViews;
+    @Builder.Default
+    private List<ArticleView> articleViews = new ArrayList<>();
 
     public void increaseViewCount() {
         this.viewCount++;
@@ -79,33 +83,5 @@ public class Article extends BaseEntity {
 
     public boolean isNotDeleted() {
         return !this.isDeleted;
-    }
-
-    @Builder
-    public Article(
-        UUID id,
-        String source,
-        String sourceUrl,
-        String title,
-        Instant publishDate,
-        String summary,
-        Long commentCount,
-        Long viewCount,
-        Boolean isDeleted,
-        List<ArticleView> articleViews
-    ) {
-        super();
-        if (id != null) {
-            assignId(id);
-        }
-        this.source = source;
-        this.sourceUrl = sourceUrl;
-        this.title = title;
-        this.publishDate = publishDate;
-        this.summary = summary;
-        this.commentCount = commentCount != null ? commentCount : 0L;
-        this.viewCount = viewCount != null ? viewCount : 0L;
-        this.isDeleted = isDeleted != null ? isDeleted : false;
-        this.articleViews = articleViews != null ? articleViews : new ArrayList<>();
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/entity/base/BaseEntity.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/entity/base/BaseEntity.java
@@ -26,11 +26,6 @@ public abstract class BaseEntity {
     @Column(columnDefinition = "timestamp with time zone", updatable = false, nullable = false)
     private Instant createdAt;
 
-    protected void assignId(UUID id) {
-        // 백업, 복원 등의 목적
-        this.id = id;
-    }
-
     public void setIdForTest(UUID id) {
         this.id = id;
     }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/NotificationEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/NotificationEventListener.java
@@ -39,8 +39,6 @@ public class NotificationEventListener {
         String interestName = event.getInterestName();
         List<ArticleDto> articles = event.getArticles();
 
-        log.info("기사 등록 이벤트 요청 - 관심사:{}, 기사 수:{}", interestName, articles.size());
-
         articleCountMap.merge(interestId, articles.size(), Integer::sum);
         interestNameMap.putIfAbsent(interestId, interestName);
 
@@ -68,9 +66,6 @@ public class NotificationEventListener {
                 .toList();
 
             try {
-                log.info("구독 알림 전송 요청 - 관심사:{}, 구독자 수:{}, 기사 수:{}", interestName,
-                    subscribers.size(), count);
-
                 Interest interest = interestRepository.findById(interestId)
                     .orElseThrow(
                         () -> new IllegalArgumentException("해당 관심사가 존재하지 않습니다: " + interestId));
@@ -78,7 +73,6 @@ public class NotificationEventListener {
                 subscribers.forEach(subscriber -> {
                     notificationService.createNewArticleNotification(subscriber, interest, count);
                 });
-                log.info("구독 알림 전송 완료 - 관심사:{}, 구독자 수:{}", interestName, subscribers.size());
             } catch (Exception e) {
                 log.error("구독 알림 전송 실패 - 관심사:{}, 구독자 수:{}", interestName, subscribers.size());
                 throw new NotificationSendException("구독 알림 전송에 실패하였습니다");
@@ -94,15 +88,8 @@ public class NotificationEventListener {
         Comment comment = event.getComment();
         User author = comment.getAuthor();
 
-        log.info("좋아요 등록 이벤트 요청 - comment={}, likedBy={}, author={}", comment.getId(),
-            user.getNickname(), author.getId());
-
         try {
-            log.debug("좋아요 알림 전송 요청 - comment={}, likedBy={}, author={}", comment.getId(),
-                user.getNickname(), author.getId());
             notificationService.createCommentLikeNotification(user, comment);
-            log.info("좋아요 알림 전송 완료 - comment={}, likedBy={}, author={}", comment.getId(),
-                user.getNickname(), author.getId());
         } catch (Exception e) {
             log.error("좋아요 알림 전송 실패: {}", e.getMessage(), e);
             throw new NotificationSendException("좋아요 알림 전송에 실패하였습니다.");

--- a/src/main/java/com/sprint/mission/sb03monewteam1/mapper/ArticleMapper.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/mapper/ArticleMapper.java
@@ -1,11 +1,10 @@
 package com.sprint.mission.sb03monewteam1.mapper;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-
 import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
 import com.sprint.mission.sb03monewteam1.dto.CollectedArticleDto;
 import com.sprint.mission.sb03monewteam1.entity.Article;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ArticleMapper {
@@ -20,7 +19,6 @@ public interface ArticleMapper {
     @Mapping(target = "viewedByMe", source = "viewed")
     ArticleDto toDto(Article article, boolean viewed);
 
-    @Mapping(target = "id", ignore = true)
     @Mapping(target = "commentCount", ignore = true)
     @Mapping(target = "viewCount", ignore = true)
     @Mapping(target = "isDeleted", ignore = true)

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/article/ArticleRepositoryImpl.java
@@ -132,7 +132,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
 
     @Override
     public List<ArticleDto> findAllCreatedYesterday() {
-        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(0);
+        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
         Instant start = yesterday.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
         Instant end = yesterday.plusDays(1).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/article/ArticleRepositoryImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/article/ArticleRepositoryImpl.java
@@ -132,7 +132,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
 
     @Override
     public List<ArticleDto> findAllCreatedYesterday() {
-        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(0);
         Instant start = yesterday.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
         Instant end = yesterday.plusDays(1).atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant();
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleBackupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleBackupScheduler.java
@@ -29,6 +29,7 @@ public class ArticleBackupScheduler {
             log.warn("articleBackupJob이 아직 실행 중입니다.");
             return;
         }
+        log.info("스케줄러: 기사 백업 배치 잡 실행 요청");
 
         if (restartPreviousExecution()) {
             return;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectScheduler.java
@@ -23,7 +23,7 @@ public class ArticleCollectScheduler {
     private final JobOperator jobOperator;
     private final Job newsCollectJob;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public void runNewsCollectJob() {
         runJobIfNotRunning("newsCollectJob", newsCollectJob);
     }
@@ -33,6 +33,8 @@ public class ArticleCollectScheduler {
             log.warn("{}이(가) 아직 실행 중이므로 이번 실행은 건너뜁니다.", jobName);
             return;
         }
+
+        log.info("스케줄러: 기사 수집 배치 잡 실행 요청");
 
         if (restartPreviousExecution(jobName)) {
             return;

--- a/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/scheduler/LogBackupScheduler.java
@@ -25,7 +25,9 @@ public class LogBackupScheduler {
             log.warn("로그 백업 작업이 아직 실행 중이므로 이번 실행은 건너뜁니다.");
             return;
         }
+
         log.info("스케줄러: 로그 백업 배치 잡 실행 요청");
+
         try {
             JobParameters params = new JobParametersBuilder()
                 .addLong("timestamp", System.currentTimeMillis())

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -1,25 +1,5 @@
 package com.sprint.mission.sb03monewteam1.service;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.mission.sb03monewteam1.collector.HankyungNewsCollector;
@@ -53,9 +33,26 @@ import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepositor
 import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestKeywordRepository;
 import com.sprint.mission.sb03monewteam1.util.S3Util;
-
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -87,7 +84,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Value("${aws.s3.bucket:}")
     private String backupBucket;
 
-    @Value("${aws.s3.backup-prefix:articles/}")
+    @Value("${aws.s3.backup-prefix:articles}")
     private String backupPrefix;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
@@ -490,7 +487,7 @@ public class ArticleServiceImpl implements ArticleService {
                 if (items == null || !items.isArray()) {
                     return buildResult(date, restoredIds);
                 }
-                // 중복 선언 제거
+
                 List<ArticleDto> batch = new ArrayList<>(BATCH_SIZE);
                 Set<String> allSourceUrls = new HashSet<>();
                 for (JsonNode node : items) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -1,7 +1,26 @@
 package com.sprint.mission.sb03monewteam1.service;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.mission.sb03monewteam1.collector.HankyungNewsCollector;
 import com.sprint.mission.sb03monewteam1.collector.NaverNewsCollector;
@@ -16,9 +35,9 @@ import com.sprint.mission.sb03monewteam1.entity.Article;
 import com.sprint.mission.sb03monewteam1.entity.ArticleInterest;
 import com.sprint.mission.sb03monewteam1.entity.ArticleView;
 import com.sprint.mission.sb03monewteam1.entity.Comment;
+import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
-import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.NewArticleCollectEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
@@ -34,26 +53,9 @@ import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepositor
 import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestKeywordRepository;
 import com.sprint.mission.sb03monewteam1.util.S3Util;
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -129,6 +131,9 @@ public class ArticleServiceImpl implements ArticleService {
     private Instant parseToKstInstant(String value) {
         if (value == null || value.isBlank()) {
             return null;
+        }
+        if (value.endsWith("Z")) {
+            return Instant.parse(value);
         }
 
         DateTimeFormatter formatter = value.contains(".")
@@ -444,9 +449,11 @@ public class ArticleServiceImpl implements ArticleService {
         LocalDate fromDate;
         LocalDate toDate;
         try {
-            fromDate = Instant.parse(from).atZone(KST).toLocalDate();
-            toDate = Instant.parse(to).atZone(KST).toLocalDate();
-        } catch (DateTimeParseException e) {
+            Instant fromInstant = tryParseInstantOrKst(from);
+            Instant toInstant = tryParseInstantOrKst(to);
+            fromDate = fromInstant.atZone(KST).toLocalDate();
+            toDate = toInstant.atZone(KST).toLocalDate();
+        } catch (DateTimeParseException | IllegalArgumentException e) {
             throw new IllegalArgumentException("잘못된 날짜 형식입니다: " + e.getMessage(), e);
         }
 
@@ -457,8 +464,17 @@ public class ArticleServiceImpl implements ArticleService {
         return results;
     }
 
+    private Instant tryParseInstantOrKst(String value) {
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            // 타임존 없는 경우 KST로 파싱
+            return parseToKstInstant(value);
+        }
+    }
+
     private ArticleRestoreResultDto restoreByDate(LocalDate date) {
-        String key = backupPrefix + "backup-articles-" + date + ".json";
+        String key = String.format("%s/backup-articles-%s.json", backupPrefix, date);
         List<UUID> restoredIds = new ArrayList<>();
         final int BATCH_SIZE = 1000;
         try {
@@ -467,20 +483,20 @@ public class ArticleServiceImpl implements ArticleService {
                 return buildResult(date, restoredIds);
             }
 
-            List<ArticleDto> batch = new ArrayList<>(BATCH_SIZE);
-            Set<String> allSourceUrls = new HashSet<>();
             ObjectMapper mapper = objectMapper;
             try (InputStream is = new ByteArrayInputStream(data)) {
-                JsonParser parser = mapper.getFactory().createParser(is);
-                if (parser.nextToken() != JsonToken.START_ARRAY) {
+                JsonNode root = mapper.readTree(is);
+                JsonNode items = root.get("items");
+                if (items == null || !items.isArray()) {
                     return buildResult(date, restoredIds);
                 }
-
-                while (parser.nextToken() == JsonToken.START_OBJECT) {
-                    ArticleDto dto = mapper.readValue(parser, ArticleDto.class);
+                // 중복 선언 제거
+                List<ArticleDto> batch = new ArrayList<>(BATCH_SIZE);
+                Set<String> allSourceUrls = new HashSet<>();
+                for (JsonNode node : items) {
+                    ArticleDto dto = mapper.treeToValue(node, ArticleDto.class);
                     batch.add(dto);
                     allSourceUrls.add(dto.sourceUrl());
-
                     if (batch.size() == BATCH_SIZE) {
                         restoredIds.addAll(processBatch(batch, allSourceUrls));
                         batch.clear();
@@ -492,7 +508,7 @@ public class ArticleServiceImpl implements ArticleService {
                 }
             }
         } catch (Exception e) {
-            log.error("Failed to restore articles for date {}", date, e);
+            log.error("요청 날짜의 뉴스 기사 복원 실패: {}", date, e);
         }
         return buildResult(date, restoredIds);
     }
@@ -510,7 +526,6 @@ public class ArticleServiceImpl implements ArticleService {
             }
 
             Article article = Article.builder()
-                .id(dto.id())
                 .source(dto.source())
                 .sourceUrl(dto.sourceUrl())
                 .title(dto.title())

--- a/src/main/java/com/sprint/mission/sb03monewteam1/util/S3Util.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/util/S3Util.java
@@ -22,8 +22,6 @@ public class S3Util {
 
     public void upload(String bucketName, String key, InputStream inputStream, long length,
         String contentType) {
-        log.info("S3 파일 업로드 시작: bucket={}, key={}, length={}, contentType={}", bucketName, key,
-            length, contentType);
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -33,8 +31,6 @@ public class S3Util {
                 .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(inputStream, length));
-
-            log.info("S3 파일 업로드 성공: bucket={}, key={}", bucketName, key);
         } catch (Exception e) {
             log.error("S3 파일 업로드 실패: bucket={}, key={}", bucketName, key, e);
             throw new S3UploadException("S3 파일 업로드 실패: " + e.getMessage());
@@ -42,8 +38,6 @@ public class S3Util {
     }
 
     public byte[] download(String bucketName, String key) {
-        log.info("S3 파일 다운로드 시작: bucket={}, key={}", bucketName, key);
-
         try {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
@@ -53,7 +47,6 @@ public class S3Util {
             ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(
                 getObjectRequest);
 
-            log.info("S3 파일 다운로드 완료: bucket={}, key={}", bucketName, key);
             return objectBytes.asByteArray();
         } catch (Exception e) {
             log.error("S3 파일 다운로드 실패: bucket={}, key={}", bucketName, key, e);

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -26,6 +26,11 @@ spring:
     # OSIV 비활성화
     open-in-view: false
 
+aws:
+  s3:
+    logDir: logs    # 로그 경로
+    log-prefix: logs    # 로그 S3 저장 경로
+
 logging:
   level:
     root: info

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,5 +68,6 @@ aws:
     region: ${AWS_S3_REGION}
     access-key: ${AWS_S3_ACCESS_KEY}
     secret-key: ${AWS_S3_SECRET_KEY}
-    backup-prefix: articles/    # S3 저장 경로
-    log-prefix: logs/    # 로그 백업 경로
+    backup-prefix: articles    # 기사 S3 저장 경로
+    logDir: /app/logs    # 로그 경로
+    log-prefix: logs    # 로그 S3 저장 경로

--- a/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleBackupJobTest.java
@@ -1,0 +1,89 @@
+package com.sprint.mission.sb03monewteam1.batch.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.mission.sb03monewteam1.config.metric.MonewMetrics;
+import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
+import com.sprint.mission.sb03monewteam1.fixture.ArticleFixture;
+import com.sprint.mission.sb03monewteam1.util.S3Util;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@Slf4j
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class ArticleBackupJobTest {
+
+    @Mock
+    S3Util s3Util;
+    @Mock
+    MonewMetrics monewMetrics;
+    @Mock
+    Timer.Sample sample;
+    @Mock
+    ObjectMapper objectMapper;
+    @Mock
+    Timer timer;
+
+    @InjectMocks
+    ArticleBackupJobConfig config;
+
+    // MeterRegistry 테스트는 Mock 말고 반드시 실제 객체를 사용할 것...
+
+    @Test
+    void writer가_S3Util_upload를_호출() throws Exception {
+        List<ArticleDto> articles = List.of(ArticleFixture.createArticleDto());
+        String json = "[{\"id\":\"1\",\"source\":\"test\"}]";
+        byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8);
+
+        when(objectMapper.writeValueAsString(any())).thenReturn(json);
+        when(monewMetrics.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
+        when(monewMetrics.getBatchJobTimer(anyString())).thenReturn(timer);
+
+        ReflectionTestUtils.setField(config, "backupBucket", "test-bucket");
+        ReflectionTestUtils.setField(config, "backupPrefix", "articles");
+
+        ItemWriter<ArticleDto> writer = config.writer();
+        writer.write(new Chunk<>(articles));
+
+        verify(s3Util).upload(
+            eq("test-bucket"),
+            contains("articles/backup-articles-"),
+            any(InputStream.class),
+            eq((long) jsonBytes.length),
+            eq("application/json")
+        );
+    }
+
+    @Test
+    void SimpleMeterRegistry를_사용해서_메트릭_동작을_검증() {
+        var meterRegistry = new SimpleMeterRegistry();
+        Metrics.addRegistry(meterRegistry);
+
+        meterRegistry.counter("test_count").increment();
+
+        var actual = meterRegistry.counter("test_count").count();
+        assertEquals(1.0d, actual);
+    }
+}

--- a/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleCollectJobTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/ArticleCollectJobTest.java
@@ -49,7 +49,6 @@ class ArticleCollectJobTest {
 
     @BeforeEach
     void setUp() {
-        // 필요할 때마다 Job을 지정해서 사용
         jobLauncherTestUtils.setJobLauncher(jobLauncher);
     }
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfigTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/batch/job/LogBackupJobConfigTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -91,7 +92,7 @@ class LogBackupJobConfigTest {
         assertEquals(RepeatStatus.FINISHED, status);
         verify(s3Util, times(1)).upload(
             eq("test-bucket"),
-            contains("/json/"),
+            argThat(key -> key.contains("/main/") || key.contains("/debug/")),
             any(InputStream.class),
             anyLong(),
             eq("application/gzip")

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/ArticleControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/ArticleControllerTest.java
@@ -4,15 +4,16 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.when;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sprint.mission.sb03monewteam1.dto.ArticleDto;
+import com.sprint.mission.sb03monewteam1.dto.ArticleRestoreResultDto;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
@@ -274,5 +275,34 @@ class ArticleControllerTest {
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.name()))
             .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    void 기사_복구__성공() throws Exception {
+        String from = "2025-07-20T00:00:00Z";
+        String to = "2025-07-22T00:00:00Z";
+        List<ArticleRestoreResultDto> results = Arrays.asList(
+            ArticleRestoreResultDto.builder()
+                .restoreDate(Instant.parse("2025-07-20T00:00:00Z"))
+                .restoredArticleCount(10)
+                .build(),
+            ArticleRestoreResultDto.builder()
+                .restoreDate(Instant.parse("2025-07-21T00:00:00Z"))
+                .restoredArticleCount(5)
+                .build()
+        );
+
+        when(articleService.restoreArticles(from, to)).thenReturn(results);
+
+        mockMvc.perform(get("/api/articles/restore")
+                .param("from", from)
+                .param("to", to)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[0].restoreDate").value("2025-07-20T00:00:00Z"))
+            .andExpect(jsonPath("$[0].restoredArticleCount").value(10))
+            .andExpect(jsonPath("$[1].restoreDate").value("2025-07-21T00:00:00Z"))
+            .andExpect(jsonPath("$[1].restoredArticleCount").value(5));
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectSchedulerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/scheduler/ArticleCollectSchedulerTest.java
@@ -1,5 +1,7 @@
 package com.sprint.mission.sb03monewteam1.scheduler;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -36,7 +38,7 @@ class ArticleCollectSchedulerTest {
     @Test
     void newsCollectJob_스케줄러_실행_테스트() throws Exception {
         articleCollectScheduler.runNewsCollectJob();
-        verify(jobLauncher, times(1)).run(org.mockito.ArgumentMatchers.eq(newsCollectJob),
-            org.mockito.ArgumentMatchers.any());
+        verify(jobLauncher, times(1)).run(eq(newsCollectJob),
+            any());
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceTest.java
@@ -58,6 +58,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -569,7 +570,8 @@ class ArticleServiceTest {
 
         ObjectMapper realMapper = new ObjectMapper();
         realMapper.registerModule(new JavaTimeModule());
-        String json = realMapper.writeValueAsString(dtos);
+
+        String json = realMapper.writeValueAsString(Map.of("items", dtos));
         byte[] bytes = json.getBytes();
 
         when(articleRepository.findAllBySourceUrlIn(anyList()))
@@ -579,7 +581,7 @@ class ArticleServiceTest {
 
         ReflectionTestUtils.setField(articleService, "objectMapper", realMapper);
         ReflectionTestUtils.setField(articleService, "backupBucket", "test-bucket");
-        ReflectionTestUtils.setField(articleService, "backupPrefix", "backup/");
+        ReflectionTestUtils.setField(articleService, "backupPrefix", "backup");
 
         List<ArticleRestoreResultDto> results = articleService.restoreArticles(from, to);
 
@@ -602,7 +604,7 @@ class ArticleServiceTest {
             .thenReturn(null);
 
         ReflectionTestUtils.setField(articleService, "backupBucket", "test-bucket");
-        ReflectionTestUtils.setField(articleService, "backupPrefix", "backup/");
+        ReflectionTestUtils.setField(articleService, "backupPrefix", "backup");
 
         List<ArticleRestoreResultDto> results = articleService.restoreArticles(from, to);
 


### PR DESCRIPTION
### 📌 작업 개요
- 프론트 업데이트 반영 후 일부 기능 수정 필요
- 뉴스 백업 기능 관련,
  - 백업 데이터 : S3에 저장된 데이터를 의미함.
  - 현재 데이터 : RDB에 저장된 데이터(아직 백업되지 않은 데이터)를 의미함.
  - 유실된 데이터 : 물리 삭제된 기사만 복구하면 됨.

### ✅ 완료한 작업
- [x] 뉴스 백업으로부터 복구
- [x] 로그 백업 경로 변경

### 🧪 테스트 결과
- 백업으로부터 복구 확인
- 로그 정상 백업 확인

### ⚠️ 기타 참고 사항
- 뉴스 페이지에서 관련 기사 목록 드롭다운 조건 확인
  - 활동 내역 기록 필요

### Related Issue

Closes #140 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 기사 복구 API 엔드포인트가 추가되어, 지정한 날짜 범위의 기사 복구가 가능합니다.

* **버그 수정**
  * 대시보드 패널 쿼리 및 제목이 수정되어 데이터 집계가 정확해졌습니다.
  * S3 백업 경로 및 로그 디렉토리 설정이 일관성 있게 정비되었습니다.

* **기능 개선**
  * 기사 수집 스케줄러가 매일 1회에서 매시간 실행으로 변경되었습니다.
  * 기사 및 로그 백업, 복구 로직의 날짜 파싱과 S3 키 생성이 개선되었습니다.
  * JSON 파싱 방식이 트리 모델로 변경되어 복구 안정성이 향상되었습니다.

* **불필요 코드/로깅 제거**
  * 여러 클래스에서 불필요한 정보성 로그가 제거되어 로그가 간결해졌습니다.

* **테스트**
  * 기사 복구 및 백업, 로그 백업 관련 테스트가 추가 및 개선되었습니다.

* **문서 및 설정**
  * S3 관련 설정 항목이 추가 및 명확화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->