### PR TITLE
[feat] [MN-82] 댓글 목록 조회_커서 파라미터 DTO로 통합

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.sprint.mission.sb03monewteam1.controller;
 import com.sprint.mission.sb03monewteam1.controller.api.CommentApi;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentCursorRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -61,9 +62,13 @@ public class CommentController implements CommentApi {
         log.info(
             "댓글 목록 조회 요청: articleId = {}, cursor = {}, after = {}, limit = {}, orderBy = {}, direction = {}",
             articleId, cursor, after, limit, orderBy, direction);
+
+        CommentCursorRequest request = new CommentCursorRequest(articleId, cursor, after, limit, orderBy, direction);
+
         CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-            articleId, cursor, after, limit, orderBy, direction, userId
+            request, userId
         );
+
         log.info("댓글 목록 조회 완료");
         log.info("조회된 댓글 수: {}", result.content().size());
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentCursorRequest.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/dto/request/CommentCursorRequest.java
@@ -1,0 +1,18 @@
+package com.sprint.mission.sb03monewteam1.dto.request;
+
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CommentCursorRequest(
+
+    UUID articleId,
+    String cursor,
+    Instant after,
+    int limit,
+    String orderBy,
+    String direction
+) {
+}
+

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentService.java
@@ -2,6 +2,7 @@ package com.sprint.mission.sb03monewteam1.service;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentCursorRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -15,12 +16,7 @@ public interface CommentService {
     CommentDto create(CommentRegisterRequest commentRegisterRequest);
 
     CursorPageResponse<CommentDto> getCommentsWithCursorBySort(
-        UUID articleId,
-        String cursor,
-        Instant nextAfter,
-        int size,
-        String sortBy,
-        String sortDirection,
+        CommentCursorRequest request,
         UUID userId
     );
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/controller/CommentControllerTest.java
@@ -1,6 +1,5 @@
 package com.sprint.mission.sb03monewteam1.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -16,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentCursorRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -29,7 +29,6 @@ import com.sprint.mission.sb03monewteam1.exception.comment.CommentLikeNotFoundEx
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.comment.UnauthorizedCommentAccessException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidSortOptionException;
-import com.sprint.mission.sb03monewteam1.exception.user.UserNotFoundException;
 import com.sprint.mission.sb03monewteam1.fixture.ArticleFixture;
 import com.sprint.mission.sb03monewteam1.fixture.CommentFixture;
 import com.sprint.mission.sb03monewteam1.fixture.CommentLikeFixture;
@@ -176,6 +175,8 @@ public class CommentControllerTest {
             int totalCount = 10;
             int pageSize = 5;
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             List<CommentDto> commentDtos = new ArrayList<>();
 
             for (int i = 0; i < totalCount; i++) {
@@ -197,7 +198,7 @@ public class CommentControllerTest {
                 .hasNext(true)
                 .build();
 
-            given(commentService.getCommentsWithCursorBySort(eq(articleId), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId)))
+            given(commentService.getCommentsWithCursorBySort(eq(request), eq(userId)))
                 .willReturn(result);
 
             // when & then
@@ -231,6 +232,9 @@ public class CommentControllerTest {
             String sortDirection = "DESC";
             int totalCount = 10;
             int pageSize = 5;
+            String cursor = baseTime.toString();
+
+            CommentCursorRequest request = new CommentCursorRequest(articleId, cursor, null, pageSize, sortBy, sortDirection);
 
             List<CommentDto> commentDtos = new ArrayList<>();
 
@@ -242,7 +246,6 @@ public class CommentControllerTest {
                 commentDtos.add(commentDto);
             }
 
-            String cursor = baseTime.toString();
             List<CommentDto> pageContent = commentDtos.stream()
                 .filter(c -> c.createdAt().isAfter(baseTime))
                 .limit(pageSize)
@@ -257,7 +260,7 @@ public class CommentControllerTest {
                 .hasNext(true)
                 .build();
 
-            given(commentService.getCommentsWithCursorBySort(eq(articleId), eq(cursor), eq(null), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId)))
+            given(commentService.getCommentsWithCursorBySort(eq(request), eq(userId)))
                 .willReturn(result);
 
             // when & then
@@ -288,8 +291,10 @@ public class CommentControllerTest {
             String sortDirection = "DESC";
             int pageSize = 5;
 
+            CommentCursorRequest request = new CommentCursorRequest(invalidArticleId, null, null, pageSize, sortBy, sortDirection);
+
             given(commentService.getCommentsWithCursorBySort(
-                eq(invalidArticleId), any(), any(), eq(pageSize), eq(sortBy), eq(sortDirection), eq(userId))
+                eq(request), eq(userId))
             ).willThrow(new CommentException(ErrorCode.ARTICLE_NOT_FOUND));
 
             // when & then
@@ -313,8 +318,10 @@ public class CommentControllerTest {
             String sortDirection = "DESC";
             int pageSize = 5;
 
+            CommentCursorRequest request = new CommentCursorRequest(null, null, null, pageSize, invalidSortBy, sortDirection);
+
             given(commentService.getCommentsWithCursorBySort(
-                eq(null), eq(null), eq(null), eq(pageSize), eq(invalidSortBy), eq(sortDirection), eq(userId)
+                eq(request), eq(userId)
             )).willThrow(new InvalidSortOptionException(ErrorCode.INVALID_SORT_FIELD));
 
             // when & then
@@ -336,8 +343,10 @@ public class CommentControllerTest {
             String sortBy = "createdAt";
             String invalidDirection = "INVALID";
 
+            CommentCursorRequest request = new CommentCursorRequest(null, null, null, pageSize, sortBy, invalidDirection);
+
             given(commentService.getCommentsWithCursorBySort(
-                eq(null), eq(null), eq(null), eq(pageSize), eq(sortBy), eq(invalidDirection), eq(userId)
+                eq(request), eq(userId)
             )).willThrow(new InvalidSortOptionException(ErrorCode.INVALID_SORT_DIRECTION));
 
             mockMvc.perform(get("/api/comments")

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/CommentServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentDto;
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeDto;
+import com.sprint.mission.sb03monewteam1.dto.request.CommentCursorRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentRegisterRequest;
 import com.sprint.mission.sb03monewteam1.dto.request.CommentUpdateRequest;
 import com.sprint.mission.sb03monewteam1.dto.response.CursorPageResponse;
@@ -202,7 +203,6 @@ public class CommentServiceTest {
             UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
             ReflectionTestUtils.setField(user, "id", userId);
-
             int pageSize = 5;
             String sortBy = "createdAt";
             String sortDirection = "DESC";
@@ -214,6 +214,8 @@ public class CommentServiceTest {
                     .collect(Collectors.toList());
 
             List<Comment> firstPage = sorted.subList(0, pageSize + 1);
+
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
 
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
@@ -227,9 +229,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -272,6 +272,8 @@ public class CommentServiceTest {
 
             List<Comment> firstPage = sorted.subList(0, pageSize + 1);
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -284,9 +286,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -324,6 +324,8 @@ public class CommentServiceTest {
             Instant cursor = lastOfFirstPage.getCreatedAt();
             Instant after = lastOfFirstPage.getCreatedAt();
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, cursor.toString(), after, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(cursor.toString()), eq(after), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -336,9 +338,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, cursor.toString(), after, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -383,6 +383,8 @@ public class CommentServiceTest {
             Long cursor = lastOfFirstPage.getLikeCount();
             Instant after = lastOfFirstPage.getCreatedAt();
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, cursor.toString(), after, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(cursor.toString()), eq(after), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -395,9 +397,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, cursor.toString(), after, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -440,6 +440,8 @@ public class CommentServiceTest {
 
             List<Comment> lastPage = sorted.subList(pageSize, sorted.size());
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, nextCursor.toString(), nextAfter, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(nextCursor.toString()), eq(nextAfter), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -452,9 +454,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, nextCursor.toString(), nextAfter, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -486,6 +486,8 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String sortDirection = "DESC";
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -493,9 +495,7 @@ public class CommentServiceTest {
             given(commentRepository.countByArticleIdAndIsDeletedFalse(article.getId())).willReturn(0L);
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -522,6 +522,8 @@ public class CommentServiceTest {
 
             List<Comment> commentList = createCommentsWithCreatedAt(pageSize, article, user);
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(articleId), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
@@ -533,9 +535,7 @@ public class CommentServiceTest {
             });
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -558,13 +558,15 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String sortDirection = "DESC";
 
-            List<Comment> comments = createCommentsWithCreatedAt(pageSize, article, user);
+//            List<Comment> comments = createCommentsWithCreatedAt(pageSize, article, user);
+
+            CommentCursorRequest request = new CommentCursorRequest(articleId, invalidCursor, null, pageSize, sortBy, sortDirection);
 
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection, userId)
+                commentService.getCommentsWithCursorBySort(request, userId)
             ).isInstanceOf(InvalidCursorException.class)
                 .hasMessageContaining(ErrorCode.INVALID_CURSOR_DATE.getMessage());
         }
@@ -583,13 +585,15 @@ public class CommentServiceTest {
             String sortBy = "likeCount";
             String sortDirection = "DESC";
 
-            List<Comment> comments = createCommentsWithLikeCount(pageSize, article, user);
+//            List<Comment> comments = createCommentsWithLikeCount(pageSize, article, user);
+
+            CommentCursorRequest request = new CommentCursorRequest(articleId, invalidCursor, null, pageSize, sortBy, sortDirection);
 
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, invalidCursor, null, pageSize, sortBy, sortDirection, userId)
+                commentService.getCommentsWithCursorBySort(request, userId)
             ).isInstanceOf(InvalidCursorException.class)
                 .hasMessageContaining(ErrorCode.INVALID_CURSOR_COUNT.getMessage());
         }
@@ -605,11 +609,13 @@ public class CommentServiceTest {
             String sortBy = "createdAt";
             String sortDirection = "DESC";
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, invalidPageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, invalidPageSize, sortBy, sortDirection, userId)
+                commentService.getCommentsWithCursorBySort(request, userId)
             ).isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("페이지 크기는 1 이상이어야 합니다");
         }
@@ -625,11 +631,13 @@ public class CommentServiceTest {
             int pageSize = 5;
             String sortDirection = "DESC";
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, invalidSort, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, invalidSort, sortDirection, userId)
+                commentService.getCommentsWithCursorBySort(request, userId)
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_FIELD.getMessage());
@@ -644,13 +652,15 @@ public class CommentServiceTest {
             Article article = ArticleFixture.createArticleWithId(articleId);
             int pageSize = 5;
             String sortBy = "createdAt";
-            String invalidSortDirection = "unknownDirection";  // 허용되지 않은 정렬 방향
+            String invalidSortDirection = "unknownDirection";
+
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, invalidSortDirection);
 
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
 
             // when & then
             assertThatThrownBy(() ->
-                commentService.getCommentsWithCursorBySort(articleId, null, null, pageSize, sortBy, invalidSortDirection, userId)
+                commentService.getCommentsWithCursorBySort(request, userId)
             )
                 .isInstanceOf(InvalidSortOptionException.class)
                 .hasMessageContaining(ErrorCode.INVALID_SORT_DIRECTION.getMessage());
@@ -667,7 +677,6 @@ public class CommentServiceTest {
             UUID userId = UUID.randomUUID();
             User user = UserFixture.createUser();
             ReflectionTestUtils.setField(user, "id", userId);
-
             int pageSize = 5;
             String sortBy = "createdAt";
             String sortDirection = "DESC";
@@ -681,6 +690,8 @@ public class CommentServiceTest {
 
             List<Comment> firstPage = sorted.subList(0, pageSize + 1);
 
+            CommentCursorRequest request = new CommentCursorRequest(null, null, null, pageSize, sortBy, sortDirection);
+
             given(commentRepository.findCommentsWithCursorBySort(
                 eq(null), eq(null), eq(null), eq(pageSize + 1), eq(sortBy), eq(sortDirection)))
                 .willReturn(firstPage);
@@ -692,9 +703,7 @@ public class CommentServiceTest {
             );
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                null, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -731,6 +740,8 @@ public class CommentServiceTest {
 
             List<Comment> commentList = createCommentsWithCreatedAt(5, article, user);
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 any(UUID.class), any(), any(), anyInt(), anyString(), anyString()))
@@ -741,9 +752,7 @@ public class CommentServiceTest {
                 });
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -764,6 +773,8 @@ public class CommentServiceTest {
 
             List<Comment> commentList = createCommentsWithCreatedAt(5, article, user);
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, sortBy, sortDirection);
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId)).willReturn(Optional.of(article));
             given(commentRepository.findCommentsWithCursorBySort(
                 any(UUID.class), any(), any(), anyInt(), anyString(), anyString()))
@@ -774,9 +785,7 @@ public class CommentServiceTest {
             });
 
             // when
-            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(
-                articleId, null, null, pageSize, sortBy, sortDirection, userId
-            );
+            CursorPageResponse<CommentDto> result = commentService.getCommentsWithCursorBySort(request, userId);
 
             // then
             assertThat(result).isNotNull();
@@ -790,13 +799,15 @@ public class CommentServiceTest {
             UUID articleId = UUID.randomUUID();
             int pageSize = 5;
 
+            CommentCursorRequest request = new CommentCursorRequest(articleId, null, null, pageSize, "createdAt", "DESC");
+
             given(articleRepository.findByIdAndIsDeletedFalse(articleId))
                 .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() ->
                 commentService.getCommentsWithCursorBySort(
-                    articleId, null, null, pageSize, "createdAt", "DESC", userId)
+                    request, userId)
             )
                 .isInstanceOf(CommentException.class)
                 .hasMessageContaining(ErrorCode.ARTICLE_NOT_FOUND.getMessage());


### PR DESCRIPTION
### 📌 작업 개요
- 댓글 목록 조회 API의 요청 파라미터를 커서 기반 DTO(CommentCursorRequest)로 통합
- 파라미터 구조 변경에 따라 기존 테스트 코드 수정

### ✅ 완료한 작업
- [x] 커서 기반 파라미터를 DTO로 분리하여 서비스에 전달되도록 수정
- [x] 컨트롤러, 서비스 테스트 코드 수정

### 🧪 테스트 결과
- 모든 테스트 코드 통과
- 로컬 환경 테스트 완료

### ⚠️ 기타 참고 사항

### Related Issue

Closes #139 
