### PR TITLE
[refactor] [MN-83] 사용자 활동 내역 조회_로깅 개선 및 네이밍 통일

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountActivityUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/ArticleViewCountActivityUpdateEvent.java
@@ -2,7 +2,7 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import java.util.UUID;
 
-public record ArticleViewCountUpdateEvent(
+public record ArticleViewCountActivityUpdateEvent(
     UUID articleId,
     long newViewCount
 ) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeActivityCreateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeActivityCreateEvent.java
@@ -2,7 +2,6 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import com.sprint.mission.sb03monewteam1.dto.CommentLikeActivityDto;
 import java.util.UUID;
-import lombok.Builder;
 
 public record CommentLikeActivityCreateEvent(
     UUID userId,

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeCountActivityUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/CommentLikeCountActivityUpdateEvent.java
@@ -2,7 +2,7 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import java.util.UUID;
 
-public record CommentLikeCountUpdateEvent(
+public record CommentLikeCountActivityUpdateEvent(
     UUID commentId,
     long newLikeCount
 ) {

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/UserNameActivityUpdateEvent.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/UserNameActivityUpdateEvent.java
@@ -2,7 +2,7 @@ package com.sprint.mission.sb03monewteam1.event;
 
 import java.util.UUID;
 
-public record UserNameUpdateEvent(
+public record UserNameActivityUpdateEvent(
 
     UUID userId,
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/ArticleViewActivityEventListener.java
@@ -5,7 +5,7 @@ import com.sprint.mission.sb03monewteam1.document.ArticleViewActivity;
 import com.sprint.mission.sb03monewteam1.dto.ArticleViewActivityDto;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.ArticleViewActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +59,7 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleCreateEvent(ArticleViewActivityCreateEvent event) {
-        log.debug("기사 뷰 활동 ArticleViewActivityCreateEvent 리스너 실행: {}", event);
+        log.debug("ArticleViewActivityCreateEvent 리스너 실행: {}", event);
         saveUserActivity(event.userId(), event.articleViewActivityDto());
     }
 
@@ -78,7 +78,7 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleViewCountChanged(ArticleViewCountUpdateEvent event) {
+    public void handleViewCountUpdateEvent(ArticleViewCountActivityUpdateEvent event) {
         UUID articleId = event.articleId();
         long newViewCount = event.newViewCount();
 
@@ -89,6 +89,6 @@ public class ArticleViewActivityEventListener extends AbstractActivityEventListe
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, ArticleViewActivity.class);
 
-        log.info("기사 뷰 수 동기화 완료: articleId={}, 반영된 문서 수={}", articleId, result.getModifiedCount());
+        log.debug("기사 뷰 수 동기화 완료: articleId={}, 반영된 문서 수={}", articleId, result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentActivityEventListener.java
@@ -8,8 +8,8 @@ import com.sprint.mission.sb03monewteam1.dto.CommentActivityDto;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityUpdateEvent;
-import com.sprint.mission.sb03monewteam1.event.CommentLikeCountUpdateEvent;
-import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.CommentLikeCountActivityUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.UserNameActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.CommentActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +63,7 @@ public class CommentActivityEventListener extends AbstractActivityEventListener<
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handleCreateEvent(CommentActivityCreateEvent event) {
-        log.debug("리스너 실행: {}", event);
+        log.debug("CommentActivityCreateEvent 리스너 실행: {}", event);
         saveUserActivity(event.userId(), event.commentActivityDto());
     }
 
@@ -84,7 +84,7 @@ public class CommentActivityEventListener extends AbstractActivityEventListener<
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleUserNameUpdateEvent(UserNameUpdateEvent event) {
+    public void handleUserNameUpdateEvent(UserNameActivityUpdateEvent event) {
         UUID userId = event.userId();
         String newUserName = event.newUserName();
 
@@ -97,23 +97,23 @@ public class CommentActivityEventListener extends AbstractActivityEventListener<
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, CommentActivity.class);
 
-        log.info("댓글 활동 UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId,
+        log.debug("댓글 활동 UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId,
             result.getModifiedCount());
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleCommentLikeCountChangedEvent(CommentLikeCountUpdateEvent event) {
+    public void handleCommentLikeCountUpdateEvent(CommentLikeCountActivityUpdateEvent event) {
         UUID commentId = event.commentId();
         long newLikeCount = event.newLikeCount();
 
-        log.debug("댓글 좋아요 수 변경 이벤트 실행: commentId={}, newLikeCount={}", commentId, newLikeCount);
+        log.debug("CommentLikeCountUpdateEvent 리스너 실행: commentId={}, newLikeCount={}", commentId, newLikeCount);
 
         Query query = new Query(Criteria.where("comments.id").is(commentId));
         Update update = new Update().set("comments.$.likeCount", newLikeCount);
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, CommentActivity.class);
 
-        log.info("댓글 좋아요 수 변경 이벤트 완료: commentId={}, 업데이트된 문서 수={}", commentId, result.getModifiedCount());
+        log.debug("CommentLikeCountUpdateEvent 리스너 실행 완료 : commentId={}, 업데이트된 문서 수={}", commentId, result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/CommentLikeActivityEventListener.java
@@ -8,8 +8,8 @@ import com.sprint.mission.sb03monewteam1.dto.CommentLikeActivityDto;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;
-import com.sprint.mission.sb03monewteam1.event.CommentLikeCountUpdateEvent;
-import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.CommentLikeCountActivityUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.UserNameActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.CommentLikeActivityRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +77,7 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void handleUserNameUpdateForLikes(UserNameUpdateEvent event) {
+    public void handleUserNameUpdateEventForLikes(UserNameActivityUpdateEvent event) {
         UUID userId = event.userId();
         String newUserName = event.newUserName();
 
@@ -97,14 +97,14 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
         if (result.getModifiedCount() == 0) {
             log.warn("[업데이트 실패] userId={}에 대한 댓글 좋아요 수정이 적용되지 않았습니다.", userId);
         } else {
-            log.info("댓글 좋아요 활동 UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId,
+            log.debug("댓글 좋아요 활동 UserNameUpdateEvent 리스너 실행 완료 userId={}, 수정된 문서 수={}", userId,
                 result.getModifiedCount());
         }
     }
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void handleCommentActivityUpdateForLikes(CommentActivityUpdateEvent event) {
+    public void handleCommentActivityUpdateEventForLikes(CommentActivityUpdateEvent event) {
         UUID commentId = event.commentId();
         String updatedContent = event.commentActivityDto().content();
 
@@ -122,14 +122,14 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
         if (result.getModifiedCount() == 0) {
             log.warn("[업데이트 실패] commentId={}에 대한 댓글 내용 수정이 적용되지 않았습니다.", commentId);
         } else {
-            log.info("댓글 좋아요 활동 CommentActivityUpdateEvent 리스너 실행 완료 commentId={}, 수정된 문서 수={}",
+            log.debug("댓글 좋아요 활동 CommentActivityUpdateEvent 리스너 실행 완료 commentId={}, 수정된 문서 수={}",
                 commentId, result.getModifiedCount());
         }
     }
 
     @Async
     @TransactionalEventListener(phase = AFTER_COMMIT)
-    public void handleLikeCountChanged(CommentLikeCountUpdateEvent event) {
+    public void handleLikeCountUpdateEvent(CommentLikeCountActivityUpdateEvent event) {
         UUID commentId = event.commentId();
         long newLikeCount = event.newLikeCount();
 
@@ -141,7 +141,7 @@ public class CommentLikeActivityEventListener extends AbstractActivityEventListe
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, CommentLikeActivity.class);
 
-        log.info("댓글 좋아요 활동 CommentLikeCountChangedEvent 리스너 실행 완료: commentId={}, 수정 문서 수={}", commentId,
+        log.debug("댓글 좋아요 활동 CommentLikeCountChangedEvent 리스너 실행 완료: commentId={}, 수정 문서 수={}", commentId,
             result.getModifiedCount());
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/event/listener/SubscriptionActivityEventListener.java
@@ -89,7 +89,7 @@ public class SubscriptionActivityEventListener extends AbstractActivityEventList
         log.debug("[문서 검색] 조건에 맞는 문서 수={}", matchedDocs.size());
 
         UpdateResult result = mongoTemplate.updateMulti(query, update, SubscriptionActivity.class);
-        log.info("handleKeywordUpdateEvent 리스너 실행 완료: interestId={}, 수정 문서 수={}", interestId, result.getModifiedCount());
+        log.debug("handleKeywordUpdateEvent 리스너 실행 완료: interestId={}, 수정 문서 수={}", interestId, result.getModifiedCount());
     }
 
     @Async

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceImpl.java
@@ -19,7 +19,7 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.NewArticleCollectEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
@@ -110,8 +110,8 @@ public class ArticleServiceImpl implements ArticleService {
         ArticleView articleView = ArticleView.createArticleView(userId, article);
         ArticleView savedArticleView = articleViewRepository.save(articleView);
 
-        ArticleViewCountUpdateEvent event =
-            new ArticleViewCountUpdateEvent(article.getId(), article.getViewCount());
+        ArticleViewCountActivityUpdateEvent event =
+            new ArticleViewCountActivityUpdateEvent(article.getId(), article.getViewCount());
 
         eventPublisher.publishEvent(event);
         log.debug("기사 뷰 활동 내역 동기화 이벤트 발행 완료: {}", event);

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/CommentServiceImpl.java
@@ -16,7 +16,7 @@ import com.sprint.mission.sb03monewteam1.event.CommentActivityDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityCreateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeActivityDeleteEvent;
-import com.sprint.mission.sb03monewteam1.event.CommentLikeCountUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.CommentLikeCountActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.event.CommentLikeEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.comment.CommentAlreadyLikedException;
@@ -300,8 +300,8 @@ public class CommentServiceImpl implements CommentService {
         eventPublisher.publishEvent(new CommentLikeEvent(user, comment));
         log.info("좋아요 등록 알림 이벤트 발행: likedBy={}, comment={}", user.getId(), comment.getId());
 
-        CommentLikeCountUpdateEvent countEvent =
-            new CommentLikeCountUpdateEvent(commentId, comment.getLikeCount());
+        CommentLikeCountActivityUpdateEvent countEvent =
+            new CommentLikeCountActivityUpdateEvent(commentId, comment.getLikeCount());
         eventPublisher.publishEvent(countEvent);
         log.debug("댓글 좋아요 사용 기록 동기화 이벤트 발행 완료: {}", countEvent);
 

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserActivityServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserActivityServiceImpl.java
@@ -8,11 +8,13 @@ import com.sprint.mission.sb03monewteam1.dto.*;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import com.sprint.mission.sb03monewteam1.repository.mongodb.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserActivityServiceImpl implements UserActivityService {
@@ -24,29 +26,56 @@ public class UserActivityServiceImpl implements UserActivityService {
     private final ArticleViewActivityRepository articleViewActivityRepository;
 
     public UserActivityDto getUserActivity(UUID userId) {
+        log.info("사용자 활동 조회 요청: userId={}", userId);
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
+        log.debug("사용자 조회 성공: userId={}, email={}", user.getId(), user.getEmail());
+
         List<SubscriptionDto> subscriptions = subscriptionActivityRepository.findById(userId)
-            .map(SubscriptionActivity::getSubscriptions)
-            .orElse(List.of());
+            .map(activity -> {
+                log.debug("구독 활동 조회 성공: 수={}", activity.getSubscriptions().size());
+                return activity.getSubscriptions();
+            })
+            .orElseGet(() -> {
+                log.debug("구독 활동 없음: userId={}", userId);
+                return List.of();
+            });
 
         List<CommentActivityDto> comments = commentActivityRepository
             .findRecent10CommentsByUserId(userId)
-            .map(CommentActivity::getComments)
-            .orElse(List.of());
+            .map(activity -> {
+                log.debug("댓글 활동 조회 성공: 수={}", activity.getComments().size());
+                return activity.getComments();
+            })
+            .orElseGet(() -> {
+                log.debug("댓글 활동 없음: userId={}", userId);
+                return List.of();
+            });
 
         List<CommentLikeActivityDto> commentLikes = commentLikeActivityRepository
             .findRecent10CommentLikesByUserId(userId)
-            .map(CommentLikeActivity::getCommentLikes)
-            .orElse(List.of());
+            .map(activity -> {
+                log.debug("댓글 좋아요 활동 조회 성공: 수={}", activity.getCommentLikes().size());
+                return activity.getCommentLikes();
+            })
+            .orElseGet(() -> {
+                log.debug("댓글 좋아요 활동 없음: userId={}", userId);
+                return List.of();
+            });
 
         List<ArticleViewActivityDto> articleViews = articleViewActivityRepository
             .findRecent10ArticleViewsByUserId(userId)
-            .map(ArticleViewActivity::getArticleViews)
-            .orElse(List.of());
+            .map(activity -> {
+                log.debug("기사 조회 활동 조회 성공: 수={}", activity.getArticleViews().size());
+                return activity.getArticleViews();
+            })
+            .orElseGet(() -> {
+                log.debug("기사 조회 활동 없음: userId={}", userId);
+                return List.of();
+            });
 
-        return UserActivityDto.builder()
+        UserActivityDto result = UserActivityDto.builder()
             .id(user.getId())
             .email(user.getEmail())
             .nickname(user.getNickname())
@@ -56,5 +85,8 @@ public class UserActivityServiceImpl implements UserActivityService {
             .commentLikes(commentLikes)
             .articleViews(articleViews)
             .build();
+
+        log.info("사용자 활동 응답 생성 완료: userId={}", userId);
+        return result;
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -119,7 +119,7 @@ public class UserServiceImpl implements UserService {
         log.info("사용자 정보 수정 완료 - id={}, nickname={}", user.getId(), user.getNickname());
 
         eventPublisher.publishEvent(new UserNameActivityUpdateEvent(userId, request.nickname()));
-        log.debug("UserNameUpdateEvent 발행 완료: userId={}, newUserName={}", userId, request.nickname());
+        log.debug("UserNameActivityUpdateEvent 발행 완료: userId={}, newUserName={}", userId, request.nickname());
 
         return userMapper.toDto(user);
     }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -9,7 +9,7 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
-import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.UserNameActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;
 import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
 import com.sprint.mission.sb03monewteam1.exception.user.InvalidEmailOrPasswordException;
@@ -118,7 +118,7 @@ public class UserServiceImpl implements UserService {
 
         log.info("사용자 정보 수정 완료 - id={}, nickname={}", user.getId(), user.getNickname());
 
-        eventPublisher.publishEvent(new UserNameUpdateEvent(userId, request.nickname()));
+        eventPublisher.publishEvent(new UserNameActivityUpdateEvent(userId, request.nickname()));
         log.debug("UserNameUpdateEvent 발행 완료: userId={}, newUserName={}", userId, request.nickname());
 
         return userMapper.toDto(user);

--- a/src/test/java/com/sprint/mission/sb03monewteam1/config/TestConfig.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/config/TestConfig.java
@@ -15,7 +15,6 @@ public class TestConfig {
         return new EmbeddedDatabaseBuilder()
             .setType(EmbeddedDatabaseType.H2)
             .addScript("classpath:schema.sql")
-//                .addScript("classpath:org/springframework/batch/core/schema-h2.sql")
             .build();
     }
 }

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/ArticleServiceTest.java
@@ -34,7 +34,7 @@ import com.sprint.mission.sb03monewteam1.entity.InterestKeyword;
 import com.sprint.mission.sb03monewteam1.entity.User;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityBulkDeleteEvent;
 import com.sprint.mission.sb03monewteam1.event.ArticleViewActivityCreateEvent;
-import com.sprint.mission.sb03monewteam1.event.ArticleViewCountUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.ArticleViewCountActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.article.ArticleNotFoundException;
 import com.sprint.mission.sb03monewteam1.exception.common.InvalidCursorException;
@@ -156,7 +156,7 @@ class ArticleServiceTest {
         verify(articleRepository).findByIdAndIsDeletedFalse(articleId);
         verify(articleViewRepository).save(any(ArticleView.class));
         verify(eventPublisher).publishEvent(any(ArticleViewActivityCreateEvent.class));
-        verify(eventPublisher).publishEvent(any(ArticleViewCountUpdateEvent.class));
+        verify(eventPublisher).publishEvent(any(ArticleViewCountActivityUpdateEvent.class));
     }
 
     @Test

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -20,7 +20,7 @@ import com.sprint.mission.sb03monewteam1.entity.Comment;
 import com.sprint.mission.sb03monewteam1.entity.CommentLike;
 import com.sprint.mission.sb03monewteam1.entity.Subscription;
 import com.sprint.mission.sb03monewteam1.entity.User;
-import com.sprint.mission.sb03monewteam1.event.UserNameUpdateEvent;
+import com.sprint.mission.sb03monewteam1.event.UserNameActivityUpdateEvent;
 import com.sprint.mission.sb03monewteam1.exception.ErrorCode;
 import com.sprint.mission.sb03monewteam1.exception.user.EmailAlreadyExistsException;
 import com.sprint.mission.sb03monewteam1.exception.user.ForbiddenAccessException;
@@ -285,7 +285,7 @@ public class UserServiceTest {
             then(userRepository).should().findByIdAndIsDeletedFalse(userId);
             then(userMapper).should().toDto(existedUser);
 
-            verify(eventPublisher).publishEvent(any(UserNameUpdateEvent.class));
+            verify(eventPublisher).publishEvent(any(UserNameActivityUpdateEvent.class));
         }
 
         @Test


### PR DESCRIPTION
### 📌 작업 개요
- 사용자 활동 내역 조회 클래스명, 메서드명 수정
- 사용자 활동 내역 조회 로깅 개선

### ✅ 완료한 작업
- [x] 사용자 활동 내역 조회 클래스명, 메서드명 수정
- [x] 사용자 활동 내역 조회 로깅 개선

### 🧪 테스트 결과
- 

### ⚠️ 기타 참고 사항
- 

### Related Issue

Closes #143 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 여러 이벤트 클래스 및 관련 메서드의 이름이 Activity 기반으로 일괄 변경되었습니다.
  * 주요 이벤트 리스너 및 서비스에서 이벤트 클래스명과 메서드명이 일관성 있게 수정되었습니다.
  * 일부 로그 레벨이 INFO에서 DEBUG로 조정되었습니다.
  * 사용자 활동 조회 기능에 상세 로그가 추가되어 추적성이 향상되었습니다.

* **Tests**
  * 이벤트 클래스명 변경에 따라 관련 테스트 코드가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->