### PR TITLE
[MN-84] docs: UserActivityApi Swagger 문서 추가

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/UserActivityController.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/UserActivityController.java
@@ -1,9 +1,11 @@
 package com.sprint.mission.sb03monewteam1.controller;
 
+import com.sprint.mission.sb03monewteam1.controller.api.UserActivityApi;
 import com.sprint.mission.sb03monewteam1.dto.UserActivityDto;
 import com.sprint.mission.sb03monewteam1.service.UserActivityService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,12 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/user-activities")
 @RequiredArgsConstructor
-public class UserActivityController {
+public class UserActivityController implements UserActivityApi {
 
     private final UserActivityService userActivityService;
 
     @GetMapping("/{userId}")
-    public UserActivityDto getUserActivity(@PathVariable UUID userId) {
-        return userActivityService.getUserActivity(userId);
+    public ResponseEntity<UserActivityDto> getUserActivity(@PathVariable UUID userId) {
+        UserActivityDto result = userActivityService.getUserActivity(userId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/UserActivityApi.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/controller/api/UserActivityApi.java
@@ -1,0 +1,46 @@
+package com.sprint.mission.sb03monewteam1.controller.api;
+
+import com.sprint.mission.sb03monewteam1.dto.UserActivityDto;
+import com.sprint.mission.sb03monewteam1.exception.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "사용자 활동 내역 관리", description = "사용자의 기사 조회, 댓글, 좋아요, 구독 활동 조회 API")
+public interface UserActivityApi {
+
+    @Operation(summary = "사용자 활동 조회", description = "특정 사용자의 활동 내역(조회, 댓글, 좋아요, 구독 등)을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "사용자 활동 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UserActivityDto.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자를 찾을 수 없음",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class)
+            )
+        )
+    })
+    ResponseEntity<UserActivityDto> getUserActivity(@PathVariable UUID userId);
+}


### PR DESCRIPTION
### 📌 작업 개요
- UserActivityApi Swagger 문서 작성

### ✅ 완료한 작업
- [x] UserActivityApi Swagger 문서 작성
- [x] Controller 반환 타입을 ResponseEntity로 수정

### 🧪 테스트 결과

### ⚠️ 기타 참고 사항

### Related Issue 

Closes #148 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 활동 내역 조회 API가 명확하게 정의되고, OpenAPI/Swagger 문서화가 추가되었습니다.

* **개선 사항**
  * 사용자 활동 조회 시 응답 형식이 명확한 HTTP 응답(ResponseEntity)으로 변경되어, 상태 코드 및 에러 처리 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->