### PR TITLE
[merge] 사용자 알림 삭제 로직 추가

### DIFF
--- a/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/repository/jpa/notification/NotificationRepository.java
@@ -28,4 +28,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
     @Transactional
     @Query("DELETE FROM Notification n WHERE n.isChecked = true AND n.updatedAt < :threshold")
     int deleteCheckedNotificationsBefore(@Param("threshold") Instant threshold);
+
+    void deleteAllByUserId(UUID userId);
 }

--- a/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
+++ b/src/main/java/com/sprint/mission/sb03monewteam1/service/UserServiceImpl.java
@@ -18,6 +18,7 @@ import com.sprint.mission.sb03monewteam1.mapper.UserMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestRepository;
+import com.sprint.mission.sb03monewteam1.repository.jpa.notification.NotificationRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.subscription.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import java.util.List;
@@ -39,6 +40,7 @@ public class UserServiceImpl implements UserService {
     private final InterestRepository interestRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
     private final UserMapper userMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -157,10 +159,13 @@ public class UserServiceImpl implements UserService {
             commentLikeRepository.deleteByCommentId(comment.getId());
             commentRepository.delete(comment);
         });
+
         commentLikeRepository.deleteByUserId(userId);
         log.debug("댓글 좋아요 객체 삭제 완료");
         subscriptionRepository.deleteByUserId(userId);
         log.debug("구독 객체 삭제 완료");
+        notificationRepository.deleteAllByUserId(userId);
+        log.debug("알림 객체 삭제 완료");
         userRepository.deleteById(userId);
         log.debug("사용자 삭제 완료");
 

--- a/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
+++ b/src/test/java/com/sprint/mission/sb03monewteam1/service/UserServiceTest.java
@@ -35,6 +35,7 @@ import com.sprint.mission.sb03monewteam1.mapper.UserMapper;
 import com.sprint.mission.sb03monewteam1.repository.jpa.commentLike.CommentLikeRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.comment.CommentRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.interest.InterestRepository;
+import com.sprint.mission.sb03monewteam1.repository.jpa.notification.NotificationRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.subscription.SubscriptionRepository;
 import com.sprint.mission.sb03monewteam1.repository.jpa.user.UserRepository;
 import java.time.Instant;
@@ -71,6 +72,9 @@ public class UserServiceTest {
     private CommentRepository commentRepository;
 
     @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
     private UserMapper userMapper;
 
     @InjectMocks
@@ -87,6 +91,7 @@ public class UserServiceTest {
         assertNotNull(interestRepository);
         assertNotNull(commentLikeRepository);
         assertNotNull(commentRepository);
+        assertNotNull(notificationRepository);
         assertNotNull(userMapper);
         assertNotNull(userService);
     }
@@ -438,6 +443,7 @@ public class UserServiceTest {
             willDoNothing().given(commentRepository).delete(any());
             willDoNothing().given(commentLikeRepository).deleteByUserId(userId);
             willDoNothing().given(subscriptionRepository).deleteByUserId(userId);
+            willDoNothing().given(notificationRepository).deleteAllByUserId(userId);
             willDoNothing().given(userRepository).deleteById(userId);
 
             // When
@@ -509,6 +515,7 @@ public class UserServiceTest {
             willDoNothing().given(commentRepository).delete(any());
             willDoNothing().given(commentLikeRepository).deleteByUserId(userId);
             willDoNothing().given(subscriptionRepository).deleteByUserId(userId);
+            willDoNothing().given(notificationRepository).deleteAllByUserId(userId);
             willDoNothing().given(userRepository).deleteById(userId);
 
             // When


### PR DESCRIPTION
### 📌 작업 개요
- 사용자 물리 삭제 시 사용자 알림도 같이 삭제되도록 코드 추가

### ✅ 완료한 작업
- [x] 사용자 물리 삭제 시 사용자 알림도 같이 삭제되는 코드 추가
- [x] 테스트 코드 수정

### 🧪 테스트 결과
- 로컬 테스트 완료
- Postman 테스트 완료
